### PR TITLE
API improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Breaking** Use `mio-extras` instead of `mio-more` which is not maintained.
 - **Breaking** Reexport `mio` rather than selectively re-exporting some of its types.
+- Add a method to `Generic` to retrive the inner `Rc`
 
 ## 0.3.2 -- 2018-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Breaking** Use `mio-extras` instead of `mio-more` which is not maintained.
 - **Breaking** Reexport `mio` rather than selectively re-exporting some of its types.
-- Add a method to `Generic` to retrive the inner `Rc`
+- Add methods to `Generic` to retrive the inner `Rc` and construct it from an `Rc`
 - **Breaking** `LoopHandle::insert_source` now allows to retrieve the source on error.
 
 ## 0.3.2 -- 2018-09-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking** Use `mio-extras` instead of `mio-more` which is not maintained.
 - **Breaking** Reexport `mio` rather than selectively re-exporting some of its types.
 - Add a method to `Generic` to retrive the inner `Rc`
+- **Breaking** `LoopHandle::insert_source` now allows to retrieve the source on error.
 
 ## 0.3.2 -- 2018-09-25
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ extern crate mio_extras;
 #[cfg(unix)]
 extern crate nix;
 
-pub use self::loop_logic::{EventLoop, LoopHandle, LoopSignal};
+pub use self::loop_logic::{EventLoop, InsertError, LoopHandle, LoopSignal};
 pub use self::sources::*;
 
 mod list;

--- a/src/sources/channel.rs
+++ b/src/sources/channel.rs
@@ -153,7 +153,8 @@ mod tests {
                 Event::Closed => {
                     got.1 = true;
                 }
-            }).unwrap();
+            }).map_err(Into::<io::Error>::into)
+            .unwrap();
 
         // nothing is sent, nothing is received
         event_loop

--- a/src/sources/generic.rs
+++ b/src/sources/generic.rs
@@ -54,6 +54,11 @@ impl<E: Evented + 'static> Generic<E> {
         self.pollopts = pollopts;
     }
 
+    /// Get a clone of the inner `Rc` wrapping your event source
+    pub fn clone_inner(&self) -> Rc<RefCell<E>> {
+        self.inner.clone()
+    }
+
     /// Unwrap the `Generic` source to retrieve the underlying `Evented`.
     ///
     /// If you didn't clone the `Rc<RefCell<E>>` from the `Event<E>` you received,

--- a/src/sources/generic.rs
+++ b/src/sources/generic.rs
@@ -235,7 +235,7 @@ impl<Data, E: Evented + 'static, F: FnMut(Event<E>, &mut Data)> EventDispatcher<
 
 #[cfg(test)]
 mod test {
-    use std::io::{Read, Write};
+    use std::io::{self, Read, Write};
 
     use super::{Event, Generic};
     #[cfg(unix)]
@@ -265,7 +265,8 @@ mod test {
                 assert_eq!(&buffer[..6], &[1, 2, 3, 4, 5, 6]);
 
                 *d = true;
-            }).unwrap();
+            }).map_err(Into::<io::Error>::into)
+            .unwrap();
 
         event_loop
             .dispatch(Some(::std::time::Duration::from_millis(0)), &mut dispached)

--- a/src/sources/generic.rs
+++ b/src/sources/generic.rs
@@ -22,7 +22,7 @@ pub struct Generic<E: Evented + 'static> {
 }
 
 impl<E: Evented + 'static> Generic<E> {
-    /// Wrap a `Evented` type into a `Generic` event source
+    /// Wrap an `Evented` type into a `Generic` event source
     ///
     /// It is initialized with no interest nor poll options,
     /// as such you should set them using the `set_interest`
@@ -31,6 +31,20 @@ impl<E: Evented + 'static> Generic<E> {
     pub fn new(source: E) -> Generic<E> {
         Generic {
             inner: Rc::new(RefCell::new(source)),
+            interest: Ready::empty(),
+            pollopts: PollOpt::empty(),
+        }
+    }
+
+    /// Wrap an `Evented` type from an `Rc` into a `Generic` event source
+    ///
+    /// Same as the `new` method, but you can provide a source that is alreay
+    /// in a reference counted pointer, so that `Generic` won't add a new
+    /// layer. This is useful if you need to share this source accross multiple
+    /// modules, and `calloop` is not the first one to be initialized.
+    pub fn from_rc(source: Rc<RefCell<E>>) -> Generic<E> {
+        Generic {
+            inner: source,
             interest: Ready::empty(),
             pollopts: PollOpt::empty(),
         }

--- a/src/sources/timer.rs
+++ b/src/sources/timer.rs
@@ -182,6 +182,7 @@ impl<Data, T, F: FnMut((T, TimerHandle<T>), &mut Data)> EventDispatcher<Data>
 
 #[cfg(test)]
 mod tests {
+    use std::io;
     use std::time::Duration;
 
     use super::*;
@@ -197,7 +198,8 @@ mod tests {
         let timer = evl_handle
             .insert_source(Timer::<()>::new(), move |((), _), f| {
                 *f = true;
-            }).unwrap();
+            }).map_err(Into::<io::Error>::into)
+            .unwrap();
 
         timer.handle().add_timeout(Duration::from_millis(300), ());
 
@@ -227,7 +229,8 @@ mod tests {
         let timer = evl_handle
             .insert_source(Timer::new(), |(val, _), fired: &mut Vec<u32>| {
                 fired.push(val);
-            }).unwrap();
+            }).map_err(Into::<io::Error>::into)
+            .unwrap();
 
         timer.handle().add_timeout(Duration::from_millis(300), 1);
         timer.handle().add_timeout(Duration::from_millis(100), 2);
@@ -265,7 +268,8 @@ mod tests {
         let timer = evl_handle
             .insert_source(Timer::new(), |(val, _), fired: &mut Vec<u32>| {
                 fired.push(val)
-            }).unwrap();
+            }).map_err(Into::<io::Error>::into)
+            .unwrap();
 
         let timeout1 = timer.handle().add_timeout(Duration::from_millis(300), 1);
         let timeout2 = timer.handle().add_timeout(Duration::from_millis(100), 2);

--- a/tests/signals.rs
+++ b/tests/signals.rs
@@ -18,6 +18,7 @@ mod test {
     extern crate calloop;
     extern crate nix;
 
+    use std::io;
     use std::time::Duration;
 
     use self::calloop::signals::{Signal, Signals};
@@ -45,7 +46,8 @@ mod test {
                     assert!(evt.signal() == Signal::SIGUSR1);
                     *rcv = true;
                 },
-            ).unwrap();
+            ).map_err(Into::<io::Error>::into)
+            .unwrap();
 
         // send ourselves a SIGUSR1
         kill(Pid::this(), Signal::SIGUSR1).unwrap();
@@ -69,7 +71,8 @@ mod test {
                 move |evt, rcv| {
                     *rcv = Some(evt.signal());
                 },
-            ).unwrap();
+            ).map_err(Into::<io::Error>::into)
+            .unwrap();
 
         signal_source.add_signals(&[Signal::SIGUSR2]).unwrap();
 
@@ -95,7 +98,8 @@ mod test {
                 move |evt, rcv| {
                     *rcv = Some(evt.signal());
                 },
-            ).unwrap();
+            ).map_err(Into::<io::Error>::into)
+            .unwrap();
 
         signal_source.remove_signals(&[Signal::SIGUSR2]).unwrap();
 


### PR DESCRIPTION
- add `Generic::clone_inner`
- `LoopHandle::insert_source` now allows to retrieve the inner source on insertion failure