### PR TITLE
Allow non 'static Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Allow non-`'static` dispatch `Data`. `Data` is passed as an argument to the
+  `callback`s while dispatching. This change allows defining `Data` values which
+  can live no longer than the `dispatch` call and which type can hold references
+  to other values.
+
 ## 0.6.2 -- 2020-04-23
 
 - Update the README and keywords for crates.io

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -168,7 +168,7 @@ pub struct Source<S: EventSource> {
 /// This handle allows you to cancel the callback. Dropping
 /// it will *not* cancel it.
 pub struct Idle {
-    pub(crate) callback: Rc<RefCell<dyn ErasedIdle>>,
+    pub(crate) callback: Rc<RefCell<dyn CancellableIdle>>,
 }
 
 impl Idle {
@@ -178,11 +178,11 @@ impl Idle {
     }
 }
 
-pub(crate) trait ErasedIdle {
+pub(crate) trait CancellableIdle {
     fn cancel(&mut self);
 }
 
-impl<F> ErasedIdle for Option<F> {
+impl<F> CancellableIdle for Option<F> {
     fn cancel(&mut self) {
         self.take();
     }


### PR DESCRIPTION
The dispatched `Data` is not captured in the `callback`, so it should not be constrained to be `'static`.

See new test [non_static_data](https://github.com/fengalin/calloop/blob/ab0cfaff22c0478dffd59e4f86c50cddb7fdc235/src/loop_logic.rs#L747).

I think we could also "loosen" the constraint on the `EventSource` & `callback` functions so that their lifetime be bound to the `EventLoop`'s.