### PR TITLE
Amend changelog for PR #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## Unreleased
 
 - Allow non-`'static` dispatch `Data`. `Data` is passed as an argument to the
-  `callback`s while dispatching. This change allows defining `Data` values which
-  can live no longer than the `dispatch` call and which type can hold references
-  to other values.
+  `callback`s while dispatching. This change allows defining `Data` types which
+  can hold references to other values.
 
 ## 0.6.2 -- 2020-04-23
 

--- a/src/loop_logic.rs
+++ b/src/loop_logic.rs
@@ -752,6 +752,7 @@ mod tests {
 
         {
             struct RefSender<'a>(&'a mpsc::Sender<()>);
+            let mut ref_sender = RefSender(&sender);
 
             let mut event_loop = EventLoop::<RefSender<'_>>::new().unwrap();
             let (ping, ping_source) = make_ping().unwrap();
@@ -764,12 +765,9 @@ mod tests {
 
             ping.ping();
 
-            {
-                let mut ref_sender = RefSender(&sender);
-                event_loop
-                    .dispatch(Duration::from_millis(0), &mut ref_sender)
-                    .unwrap();
-            }
+            event_loop
+                .dispatch(Duration::from_millis(0), &mut ref_sender)
+                .unwrap();
         }
 
         receiver.recv().unwrap();


### PR DESCRIPTION
After further investigations, it turns out that only the "type which can
hold a reference to other values" part is actually an enhancement further
to PR #18. The "allows defining Data values which can live no longer than
the dispatch call" was already possible before. Sorry about that...