### PR TITLE
Add support for openbsd, netbsd, and dragonfly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Allow non-`'static` dispatch `Data`. `Data` is passed as an argument to the
   `callback`s while dispatching. This change allows defining `Data` types which
   can hold references to other values.
+- Add support for `openbsd`, `netbsd`, and `dragonfly`.
 
 ## 0.6.2 -- 2020-04-23
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ codecov = { repository = "Smithay/calloop" }
 
 [dependencies]
 log = "0.4"
-nix = "0.17"
+nix = "0.18"
 
 [[test]]
 name = "signals"

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -5,9 +5,19 @@ mod epoll;
 #[cfg(target_os = "linux")]
 use epoll::Epoll as Poller;
 
-#[cfg(target_os = "freebsd")]
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 mod kqueue;
-#[cfg(target_os = "freebsd")]
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 use kqueue::Kqueue as Poller;
 
 /// Possible modes for registering a file descriptor


### PR DESCRIPTION
The build was tested here https://builds.sr.ht/~kchibisov/job/265577 . I can't test netbsd and dragonfly, but dragonfly is similar to freebsd, and have all required things, and netbsd also expose all the filters you're using. However I'm fine to add just openbsd, if you really want a test on netbsd/dragonfly.