### PR TITLE
Implement `std::error::Error` for `InsertError<E>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   `callback`s while dispatching. This change allows defining `Data` types which
   can hold references to other values.
 - Add support for `openbsd`, `netbsd`, and `dragonfly`.
+- `InsertError<E>` now implements `std::error::Error`.
 
 ## 0.6.2 -- 2020-04-23
 

--- a/src/loop_logic.rs
+++ b/src/loop_logic.rs
@@ -52,9 +52,23 @@ impl<E> Debug for InsertError<E> {
 }
 
 #[cfg(not(tarpaulin_include))]
+impl<E> std::fmt::Display for InsertError<E> {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(formatter, "{}", self.error)
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
 impl<E> From<InsertError<E>> for io::Error {
     fn from(e: InsertError<E>) -> io::Error {
         e.error
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+impl<E> std::error::Error for InsertError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.error.source()
     }
 }
 


### PR DESCRIPTION
Fixes #22.