### PR TITLE
channel: signal readinnes after sending message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+#### Fixes
+
+- Channel now signals readinnes after the event has actually been sent, fixing a race
+  condition where the event loop would try to read the message before it has been
+  written.
+
 ## 0.6.4 -- 2020-08-30
 
 #### Fixes


### PR DESCRIPTION
Doing it the other way around can be racy in multithreaded contexts,
causing the event loop to wake-up and try to read the message before it
has even been written, and thus missing it.