### PR TITLE
Erase closure type parameter on Dispatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.39.0', 'stable', 'beta']
+        rust: ['1.40.0', 'stable', 'beta']
       
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+#### Breaking changes
+
+- The `Dispatcher` type no longer has the closure type within its type parameters,
+  but instead now has an explicit lifetime parameter, as well as the source type `S`
+  and the event loop `Data` type. This allows the type to be explicitly named and
+  stored into an other struct.
+
 #### Additions
 
 - `Token` now has a method `with_sub_id()` that returns a copy of the token

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@
 //! Currently, only Linux and the *BSD are supported.
 
 #![warn(missing_docs)]
+#![allow(clippy::needless_doctest_main)]
 
 mod sys;
 

--- a/src/loop_logic.rs
+++ b/src/loop_logic.rs
@@ -129,13 +129,12 @@ impl<'l, Data> LoopHandle<'l, Data> {
     /// Use this function if you need access to the event source after its insertion in the loop.
     ///
     /// See also `insert_source`.
-    pub fn register_dispatcher<S, F>(
+    pub fn register_dispatcher<S>(
         &self,
-        dispatcher: Dispatcher<S, F>,
+        dispatcher: Dispatcher<'l, S, Data>,
     ) -> io::Result<RegistrationToken>
     where
         S: EventSource + 'l,
-        F: FnMut(S::Event, &mut S::Metadata, &mut Data) -> S::Ret + 'l,
     {
         let mut sources = self.inner.sources.borrow_mut();
         let mut poll = self.inner.poll.borrow_mut();
@@ -722,7 +721,7 @@ mod tests {
         .unwrap();
 
         let source = Generic::from_fd(sock1, Interest::READ, Mode::Level);
-        let mut dispatcher = Dispatcher::new(source, |_, fd, dispatched| {
+        let dispatcher = Dispatcher::new(source, |_, fd, dispatched| {
             *dispatched = true;
             // read all contents available to drain the socket
             let mut buf = [0u8; 32];

--- a/tests/signals.rs
+++ b/tests/signals.rs
@@ -64,7 +64,7 @@ mod test {
         let mut event_loop = EventLoop::try_new().unwrap();
 
         let mut signal_received = None;
-        let mut dispatcher = Dispatcher::new(
+        let dispatcher = Dispatcher::new(
             Signals::new(&[Signal::SIGUSR1]).unwrap(),
             move |evt, &mut (), rcv| {
                 *rcv = Some(evt.signal());
@@ -94,7 +94,7 @@ mod test {
         let mut event_loop = EventLoop::try_new().unwrap();
 
         let mut signal_received = None;
-        let mut dispatcher = Dispatcher::new(
+        let dispatcher = Dispatcher::new(
             Signals::new(&[Signal::SIGUSR1, Signal::SIGUSR2]).unwrap(),
             move |evt, &mut (), rcv| {
                 *rcv = Some(evt.signal());


### PR DESCRIPTION
This erases the `F` type parameter of `Dispatcher`, replacing it with an explicit lifetime and the eventloop `Data`. This allows the type to be explicitly named and stored in an other struct.