### PR TITLE
Update `nix` to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ codecov = { repository = "Smithay/calloop" }
 
 [dependencies]
 log = "0.4"
-nix = "0.22"
+nix = "0.23"
 futures-util = { version = "0.3.5", optional = true, default-features = false, features = ["std"]}
 futures-io = { version = "0.3.5", optional = true }
 slotmap = "1.0"


### PR DESCRIPTION
Reason: https://rustsec.org/advisories/RUSTSEC-2021-0119.html

If this patch lands, it would be nice to publish a new version of this crate.