### PR TITLE
CI: adjust coverage measurement

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,5 +20,5 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - env LLVM_PROFILE_FILE="calloop-%p-%m.profraw" RUSTFLAGS="-Zinstrument-coverage" cargo test --all-features
-    - grcov . --binary-path ./target/debug -s . -t lcov --branch --llvm --ignore-not-existing --ignore "/*" --ignore "tests/*" --excl-br-start "mod tests \{" --excl-start "mod tests \{" --excl-br-line "#\[derive\(" --excl-line "#\[derive\(" -o lcov.info
+    - grcov . --binary-path ./target/debug -s . -t lcov --branch --llvm --ignore-not-existing --keep-only "src/sys/*" --excl-br-start "mod tests \{" --excl-start "mod tests \{" --excl-br-line "#\[derive\(" --excl-line "#\[derive\(" -o lcov.info
     - bash -c 'bash <(curl -s https://codecov.io/bash) -f lcov.info'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: --ignore-tests --all-features
+          args: --ignore-tests --all-features --exclude-files "doc/*"
       
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
- only use grcov on FreeBSD to measure coverage of sys/, as it does not
  respect ignore instructions
- exclude doc/* from coverage