### PR TITLE
ci: don't count coverage for dead code in grcov

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,6 +19,6 @@ task:
     - rustup component add llvm-tools-preview
   test_script:
     - . $HOME/.cargo/env
-    - env LLVM_PROFILE_FILE="calloop-%p-%m.profraw" RUSTFLAGS="-Zinstrument-coverage" cargo test --all-features
-    - grcov . --binary-path ./target/debug -s . -t lcov --branch --llvm --ignore-not-existing --keep-only "src/sys/*" --excl-br-start "mod tests \{" --excl-start "mod tests \{" --excl-br-line "#\[derive\(" --excl-line "#\[derive\(" -o lcov.info
+    - env LLVM_PROFILE_FILE="calloop-%p-%m.profraw" RUSTFLAGS="-Zinstrument-coverage=except-unused-functions" cargo test --all-features
+    - grcov . --binary-path ./target/debug -s . -t lcov --branch --llvm --ignore-not-existing --excl-br-start "mod tests \{" --excl-start "mod tests \{" --excl-br-line "#\[derive\(" --excl-line "#\[derive\(" -o lcov.info
     - bash -c 'bash <(curl -s https://codecov.io/bash) -f lcov.info'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,10 @@ jobs:
           args: --all-features
         env:
           LLVM_PROFILE_FILE: "calloop-%p-%m.profraw"
-          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTFLAGS: "-Zinstrument-coverage=except-unused-functions"
 
       - name: Coverage
-        run: grcov . --binary-path ./target/debug -s . -t lcov --branch --llvm --ignore-not-existing --keep-only "src/sys/*" --excl-br-start "mod tests \{" --excl-start "mod tests \{" --excl-br-line "#\[derive\(" --excl-line "#\[derive\(" -o lcov.info
+        run: grcov . --binary-path ./target/debug -s . -t lcov --branch --llvm --ignore-not-existing --excl-br-start "mod tests \{" --excl-start "mod tests \{" --excl-br-line "#\[derive\(" --excl-line "#\[derive\(" -o lcov.info
     
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
Only use tarpaulin as the authoritative source for counting uncovered
 code in non-instantiated generic code and non-called functions, as it
has better exclude rules.