### PR TITLE
Use timerfd on linux to drive `Timer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   associated `Error` type on the `EventSource` trait.
 - **Breaking:** Many API functions now use Calloop's own error type (`calloop::Error`) instead of
   `std::io::Error` as the error variants of their returned results.
+- On Linux `Timer<T>` is now driven by `timerfd`.
 
 ## 0.9.2 -- 2021-12-27
 

--- a/src/sources/timer/threaded.rs
+++ b/src/sources/timer/threaded.rs
@@ -1,0 +1,141 @@
+//! Timer scheduler which is using thread to schedule timers.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use crate::ping::{make_ping, Ping, PingSource};
+use crate::{EventSource, Poll, PostAction, Readiness, Token, TokenFactory};
+
+use super::TimerError;
+
+#[derive(Debug)]
+pub struct TimerSource {
+    source: PingSource,
+}
+
+impl TimerSource {
+    fn new() -> std::io::Result<(Ping, Self)> {
+        let (ping, source) = make_ping()?;
+        Ok((ping, Self { source }))
+    }
+}
+
+impl EventSource for TimerSource {
+    type Event = ();
+    type Metadata = ();
+    type Ret = ();
+    type Error = TimerError;
+
+    fn process_events<C>(
+        &mut self,
+        readiness: Readiness,
+        token: Token,
+        mut callback: C,
+    ) -> Result<PostAction, Self::Error>
+    where
+        C: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
+    {
+        self.source
+            .process_events(readiness, token, |_, &mut _| {
+                callback((), &mut ());
+            })
+            .map_err(|err| TimerError(err.into()))
+    }
+
+    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+        self.source.register(poll, token_factory)
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &mut Poll,
+        token_factory: &mut TokenFactory,
+    ) -> crate::Result<()> {
+        self.source.reregister(poll, token_factory)
+    }
+
+    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+        self.source.unregister(poll)
+    }
+}
+
+#[derive(Debug)]
+pub struct TimerScheduler {
+    current_deadline: Arc<Mutex<Option<Instant>>>,
+    kill_switch: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl TimerScheduler {
+    pub fn new() -> crate::Result<(TimerScheduler, TimerSource)> {
+        let current_deadline = Arc::new(Mutex::new(None::<Instant>));
+        let thread_deadline = current_deadline.clone();
+
+        let kill_switch = Arc::new(AtomicBool::new(false));
+        let thread_kill = kill_switch.clone();
+
+        let (ping, source) = TimerSource::new()?;
+
+        let thread = std::thread::Builder::new()
+            .name("calloop timer".into())
+            .spawn(move || loop {
+                // stop if requested
+                if thread_kill.load(Ordering::Acquire) {
+                    return;
+                }
+                // otherwise check the timeout
+                let opt_deadline: Option<Instant> = {
+                    // subscope to ensure the mutex does not remain locked while the thread is parked
+                    let guard = thread_deadline.lock().unwrap();
+                    *guard
+                };
+                if let Some(deadline) = opt_deadline {
+                    if let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+                        // it is not yet expired, go to sleep until it
+                        std::thread::park_timeout(remaining);
+                    } else {
+                        // it is expired, wake the event loop and go to sleep
+                        ping.ping();
+                        std::thread::park();
+                    }
+                } else {
+                    // there is none, got to sleep
+                    std::thread::park();
+                }
+            })?;
+
+        let scheduler = TimerScheduler {
+            current_deadline,
+            kill_switch,
+            thread: Some(thread),
+        };
+        Ok((scheduler, source))
+    }
+
+    pub fn reschedule(&mut self, new_deadline: Instant) {
+        let mut deadline_guard = self.current_deadline.lock().unwrap();
+        if let Some(current_deadline) = *deadline_guard {
+            if new_deadline < current_deadline || current_deadline <= Instant::now() {
+                *deadline_guard = Some(new_deadline);
+                self.thread.as_ref().unwrap().thread().unpark();
+            }
+        } else {
+            *deadline_guard = Some(new_deadline);
+            self.thread.as_ref().unwrap().thread().unpark();
+        }
+    }
+
+    pub fn deschedule(&mut self) {
+        *(self.current_deadline.lock().unwrap()) = None;
+    }
+}
+
+impl Drop for TimerScheduler {
+    fn drop(&mut self) {
+        self.kill_switch.store(true, Ordering::Release);
+        let thread = self.thread.take().unwrap();
+        thread.thread().unpark();
+        let _ = thread.join();
+    }
+}

--- a/src/sources/timer/threaded.rs
+++ b/src/sources/timer/threaded.rs
@@ -4,10 +4,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use crate::ping::{make_ping, Ping, PingSource};
+use crate::ping::{make_ping, Ping, PingError, PingSource};
 use crate::{EventSource, Poll, PostAction, Readiness, Token, TokenFactory};
-
-use super::TimerError;
 
 #[derive(Debug)]
 pub struct TimerSource {
@@ -25,7 +23,7 @@ impl EventSource for TimerSource {
     type Event = ();
     type Metadata = ();
     type Ret = ();
-    type Error = TimerError;
+    type Error = PingError;
 
     fn process_events<C>(
         &mut self,
@@ -36,11 +34,9 @@ impl EventSource for TimerSource {
     where
         C: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
     {
-        self.source
-            .process_events(readiness, token, |_, &mut _| {
-                callback((), &mut ());
-            })
-            .map_err(|err| TimerError(err.into()))
+        self.source.process_events(readiness, token, |_, &mut _| {
+            callback((), &mut ());
+        })
     }
 
     fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {

--- a/src/sources/timer/timerfd.rs
+++ b/src/sources/timer/timerfd.rs
@@ -1,0 +1,116 @@
+//! Timer scheduler which is using timerfd system interface to schedule timers.
+
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::time::Instant;
+
+use nix::sys::time::TimeSpec;
+use nix::sys::timerfd::{self, Expiration, TimerFd, TimerSetTimeFlags};
+
+use crate::generic::Generic;
+use crate::{EventSource, Poll, PostAction, Readiness, Token, TokenFactory};
+
+use super::TimerError;
+
+#[derive(Debug)]
+pub struct TimerScheduler {
+    current_deadline: Option<Instant>,
+    timerfd: TimerFd,
+}
+
+impl TimerScheduler {
+    pub fn new() -> crate::Result<(Self, TimerSource)> {
+        let timerfd = TimerFd::new(
+            timerfd::ClockId::CLOCK_MONOTONIC,
+            timerfd::TimerFlags::TFD_CLOEXEC,
+        )?;
+
+        let source = TimerSource::new(&timerfd);
+        let scheduler = Self {
+            timerfd,
+            current_deadline: None,
+        };
+
+        Ok((scheduler, source))
+    }
+
+    pub fn reschedule(&mut self, new_deadline: Instant) {
+        let now = Instant::now();
+        let time = TimeSpec::from_duration(new_deadline.duration_since(now));
+        let time = match self.current_deadline {
+            Some(current_deadline) if new_deadline > current_deadline && current_deadline > now => {
+                return;
+            }
+            _ => time,
+        };
+
+        self.current_deadline = Some(new_deadline);
+
+        let expiration = Expiration::OneShot(time);
+        let flags = TimerSetTimeFlags::empty();
+        self.timerfd
+            .set(expiration, flags)
+            .expect("setting timerfd failed.");
+    }
+
+    pub fn deschedule(&mut self) {
+        self.current_deadline = None;
+        self.timerfd.unset().expect("failed unsetting timerfd.");
+    }
+}
+
+#[derive(Debug)]
+pub struct TimerSource {
+    source: Generic<RawFd>,
+}
+
+impl TimerSource {
+    fn new(timerfd: &TimerFd) -> Self {
+        Self {
+            source: Generic::new(
+                timerfd.as_raw_fd(),
+                crate::Interest::READ,
+                crate::Mode::Level,
+            ),
+        }
+    }
+}
+
+impl EventSource for TimerSource {
+    type Event = ();
+    type Metadata = ();
+    type Ret = ();
+    type Error = TimerError;
+
+    fn process_events<C>(
+        &mut self,
+        readiness: Readiness,
+        token: Token,
+        mut callback: C,
+    ) -> Result<PostAction, Self::Error>
+    where
+        C: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
+    {
+        self.source
+            .process_events(readiness, token, |_, &mut _| {
+                callback((), &mut ());
+                Ok(PostAction::Continue)
+            })
+            .map_err(|err| TimerError(err.into()))
+    }
+
+    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+        self.source.register(poll, token_factory)
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &mut Poll,
+        token_factory: &mut TokenFactory,
+    ) -> crate::Result<()> {
+        self.source.reregister(poll, token_factory)
+    }
+
+    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+        self.source.unregister(poll)
+    }
+}


### PR DESCRIPTION
Previously Timer was using thread for all platforms, however platforms
tend to provide efficient API to create timers. This commit makes
`Timer` use timerfd system interface on Linux.