### PR TITLE
Replace a panicking duration calculation 

### DIFF
--- a/src/sources/timer/timerfd.rs
+++ b/src/sources/timer/timerfd.rs
@@ -33,7 +33,7 @@ impl TimerScheduler {
 
     pub fn reschedule(&mut self, new_deadline: Instant) {
         let now = Instant::now();
-        let time = TimeSpec::from_duration(new_deadline.duration_since(now));
+        let time = TimeSpec::from_duration(new_deadline.saturating_duration_since(now));
         let time = match self.current_deadline {
             Some(current_deadline) if new_deadline > current_deadline && current_deadline > now => {
                 return;


### PR DESCRIPTION
…with saturating duration calculation in timerfd event source.

Under certain (intermittent) circumstances, the timerfd scheduler could
calculate a negative duration, which would cause a panic. In the context of
this calculation, the duration could just be clipped to zero, which is what
`saturating_duration_since()` does.

---

I would see this happen about one time in three when running under tarpaulin:

```none
---- loop_logic::tests::non_static_dispatcher stdout ----
thread 'loop_logic::tests::non_static_dispatcher' panicked at 'supplied instant is later than self', library/std/src/time.rs:313:48
stack backtrace:
   0: rust_begin_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
   2: core::panicking::panic_display
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:63:5
   3: core::option::expect_failed
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/option.rs:1637:5
   4: core::option::Option<T>::expect
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/option.rs:709:21
   5: std::time::Instant::duration_since
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/time.rs:313:9
   6: calloop::sources::timer::timerfd::TimerScheduler::reschedule
             at ./src/sources/timer/timerfd.rs:36:44
   7: calloop::sources::timer::TimerInner<T>::reschedule
             at ./src/sources/timer/mod.rs:276:13
   8: calloop::sources::timer::TimerInner<T>::insert
             at ./src/sources/timer/mod.rs:231:9
   9: calloop::sources::timer::TimerHandle<T>::add_timeout
             at ./src/sources/timer/mod.rs:117:9
  10: calloop::loop_logic::tests::non_static_dispatcher
             at ./src/loop_logic.rs:848:21
  11: calloop::loop_logic::tests::non_static_dispatcher::{{closure}}
             at ./src/loop_logic.rs:843:5
  12: core::ops::function::FnOnce::call_once
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/ops/function.rs:227:5
  13: core::ops::function::FnOnce::call_once
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    loop_logic::tests::non_static_dispatcher

test result: FAILED. 25 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.17s

Error: "Test failed during run"
```

Note this, well, note on `duration_since()`:

> Previous rust versions panicked when `earlier` was later than `self`. Currently this method saturates. Future versions may reintroduce the panic in some circumstances. See [Monotonicity].

It's currently inaccurate but still explains the behaviour.