### PR TITLE
Implement an eventfd-based ping source for Linux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   associated event callback.
 - **Breaking:** The minimum supported Rust version is now 1.53.0
 - Introduce `EventLoop::try_new_high_precision()` for sub-millisecond accuracy in the event loop
+- The `PingSource` event source now uses an `eventfd` instead of a pipe on Linux.
 
 ## 0.9.2 -- 2021-12-27
 

--- a/src/sources/ping/eventfd.rs
+++ b/src/sources/ping/eventfd.rs
@@ -1,0 +1,189 @@
+//! Eventfd based implementation of the ping event source.
+//!
+//! # Implementation notes
+//!
+//! The eventfd is a much lighter signalling mechanism provided by the Linux
+//! kernel. Rather than write an arbitrary sequence of bytes, it only has a
+//! 64-bit counter.
+//!
+//! To avoid closing the eventfd early, we wrap it in a RAII-style closer
+//! `CloseOnDrop` in `make_ping()`. When all the senders are dropped, another
+//! wrapper `FlagOnDrop` handles signalling this to the event source, which is
+//! the sole owner of the eventfd itself. The senders have weak references to
+//! the eventfd, and if the source is dropped before the senders, they will
+//! simply not do anything (except log a message).
+//!
+//! To differentiate between regular ping events and close ping events, we add 2
+//! to the counter for regular events and 1 for close events. In the source we
+//! can then check the LSB and if it's set, we know it was a close event. This
+//! only works if a close event never fires more than once.
+
+use std::{os::unix::io::RawFd, sync::Arc};
+
+use nix::sys::eventfd::{eventfd, EfdFlags};
+use nix::unistd::{read, write};
+
+use super::{CloseOnDrop, PingError};
+use crate::{
+    generic::Generic, EventSource, Interest, Mode, Poll, PostAction, Readiness, Token, TokenFactory,
+};
+
+// These are not bitfields! They are increments to add to the eventfd counter.
+// Since the fd can only be closed once, we can effectively use the
+// INCREMENT_CLOSE value as a bitmask when checking.
+const INCREMENT_PING: u64 = 0x2;
+const INCREMENT_CLOSE: u64 = 0x1;
+
+#[inline]
+pub fn make_ping() -> std::io::Result<(Ping, PingSource)> {
+    let read = eventfd(0, EfdFlags::EFD_CLOEXEC | EfdFlags::EFD_NONBLOCK)?;
+
+    // We only have one fd for the eventfd. If the sending end closes it when
+    // all copies are dropped, the receiving end will be closed as well. We need
+    // to make sure the fd is not closed until all holders of it have dropped
+    // it.
+
+    let fd_arc = Arc::new(CloseOnDrop(read));
+
+    let ping = Ping {
+        event: Arc::new(FlagOnDrop(Arc::clone(&fd_arc))),
+    };
+
+    let source = PingSource {
+        event: Generic::new(read, Interest::READ, Mode::Level),
+        _fd: fd_arc,
+    };
+
+    Ok((ping, source))
+}
+
+// Helper functions for the event source IO.
+
+#[inline]
+fn send_ping(fd: RawFd, count: u64) -> std::io::Result<()> {
+    assert!(count > 0);
+    match write(fd, &count.to_ne_bytes()) {
+        // The write succeeded, the ping will wake up the loop.
+        Ok(_) => Ok(()),
+
+        // The counter hit its cap, which means previous calls to write() will
+        // wake up the loop.
+        Err(nix::errno::Errno::EAGAIN) => Ok(()),
+
+        // Anything else is a real error.
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[inline]
+fn drain_ping(fd: RawFd) -> std::io::Result<u64> {
+    // The eventfd counter is effectively a u64.
+    const NBYTES: usize = 8;
+    let mut buf = [0u8; NBYTES];
+
+    match read(fd, &mut buf) {
+        // Reading from an eventfd should only ever produce 8 bytes. No looping
+        // is required.
+        Ok(NBYTES) => Ok(u64::from_ne_bytes(buf)),
+
+        Ok(_) => unreachable!(),
+
+        // Any other error can be propagated.
+        Err(e) => Err(e.into()),
+    }
+}
+
+// The event source is simply a generic source with one of the eventfds.
+#[derive(Debug)]
+pub struct PingSource {
+    event: Generic<RawFd>,
+
+    // This is held only to ensure that there is an owner of the fd that lives
+    // as long as the Generic source, so that the fd is not closed unexpectedly
+    // when all the senders are dropped.
+    _fd: Arc<CloseOnDrop>,
+}
+
+impl EventSource for PingSource {
+    type Event = ();
+    type Metadata = ();
+    type Ret = ();
+    type Error = PingError;
+
+    fn process_events<C>(
+        &mut self,
+        readiness: Readiness,
+        token: Token,
+        mut callback: C,
+    ) -> Result<PostAction, Self::Error>
+    where
+        C: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
+    {
+        self.event
+            .process_events(readiness, token, |_, &mut fd| {
+                let counter = drain_ping(fd)?;
+
+                // If the LSB is set, it means we were closed. If anything else
+                // is also set, it means we were pinged. The two are not
+                // mutually exclusive.
+                let close = (counter & INCREMENT_CLOSE) != 0;
+                let ping = (counter & (u64::MAX - 1)) != 0;
+
+                if ping {
+                    callback((), &mut ());
+                }
+
+                if close {
+                    Ok(PostAction::Remove)
+                } else {
+                    Ok(PostAction::Continue)
+                }
+            })
+            .map_err(|e| PingError(e.into()))
+    }
+
+    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+        self.event.register(poll, token_factory)
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &mut Poll,
+        token_factory: &mut TokenFactory,
+    ) -> crate::Result<()> {
+        self.event.reregister(poll, token_factory)
+    }
+
+    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+        self.event.unregister(poll)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Ping {
+    // This is an Arc because it's potentially shared with clones. The last one
+    // dropped needs to signal to the event source via the eventfd.
+    event: Arc<FlagOnDrop>,
+}
+
+impl Ping {
+    /// Send a ping to the `PingSource`.
+    pub fn ping(&self) {
+        if let Err(e) = send_ping(self.event.0 .0, INCREMENT_PING) {
+            log::warn!("[calloop] Failed to write a ping: {:?}", e);
+        }
+    }
+}
+
+/// This manages signalling to the PingSource when it's dropped. There should
+/// only ever be one of these per PingSource.
+#[derive(Debug)]
+struct FlagOnDrop(Arc<CloseOnDrop>);
+
+impl Drop for FlagOnDrop {
+    fn drop(&mut self) {
+        if let Err(e) = send_ping(self.0 .0, INCREMENT_CLOSE) {
+            log::warn!("[calloop] Failed to send close ping: {:?}", e);
+        }
+    }
+}

--- a/src/sources/ping/pipe.rs
+++ b/src/sources/ping/pipe.rs
@@ -1,0 +1,162 @@
+//! Pipe based implementation of the ping event source, using the pipe or pipe2
+//! syscall. Sending a ping involves writing to one end of a pipe, and the other
+//! end becoming readable is what wakes up the event loop.
+
+use std::{os::unix::io::RawFd, sync::Arc};
+
+use nix::fcntl::OFlag;
+use nix::unistd::{close, read, write};
+
+use super::{CloseOnDrop, PingError};
+use crate::{
+    generic::Generic, EventSource, Interest, Mode, Poll, PostAction, Readiness, Token, TokenFactory,
+};
+
+#[cfg(target_os = "macos")]
+#[inline]
+fn make_ends() -> std::io::Result<(RawFd, RawFd)> {
+    // macOS does not have pipe2, but we can emulate the behavior of pipe2 by
+    // setting the flags after calling pipe.
+    use nix::{
+        fcntl::{fcntl, FcntlArg},
+        unistd::pipe,
+    };
+
+    let (read, write) = pipe()?;
+
+    let read_flags = OFlag::from_bits_truncate(fcntl(read, FcntlArg::F_GETFD)?)
+        | OFlag::O_CLOEXEC
+        | OFlag::O_NONBLOCK;
+    let write_flags = OFlag::from_bits_truncate(fcntl(write, FcntlArg::F_GETFD)?)
+        | OFlag::O_CLOEXEC
+        | OFlag::O_NONBLOCK;
+
+    fcntl(read, FcntlArg::F_SETFL(read_flags))?;
+    fcntl(write, FcntlArg::F_SETFL(write_flags))?;
+
+    Ok((read, write))
+}
+
+#[cfg(not(target_os = "macos"))]
+#[inline]
+fn make_ends() -> std::io::Result<(RawFd, RawFd)> {
+    Ok(nix::unistd::pipe2(OFlag::O_CLOEXEC | OFlag::O_NONBLOCK)?)
+}
+
+#[inline]
+pub fn make_ping() -> std::io::Result<(Ping, PingSource)> {
+    let (read, write) = make_ends()?;
+
+    let source = PingSource {
+        pipe: Generic::new(read, Interest::READ, Mode::Level),
+    };
+    let ping = Ping {
+        pipe: Arc::new(CloseOnDrop(write)),
+    };
+    Ok((ping, source))
+}
+
+// Helper functions for the event source IO.
+
+#[inline]
+fn send_ping(fd: RawFd) -> std::io::Result<()> {
+    write(fd, &[0u8])?;
+    Ok(())
+}
+
+// The event source is simply a generic source with the FD of the read end of
+// the pipe.
+#[derive(Debug)]
+pub struct PingSource {
+    pipe: Generic<RawFd>,
+}
+
+impl EventSource for PingSource {
+    type Event = ();
+    type Metadata = ();
+    type Ret = ();
+    type Error = PingError;
+
+    fn process_events<C>(
+        &mut self,
+        readiness: Readiness,
+        token: Token,
+        mut callback: C,
+    ) -> Result<PostAction, Self::Error>
+    where
+        C: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
+    {
+        self.pipe
+            .process_events(readiness, token, |_, &mut fd| {
+                let mut buf = [0u8; 32];
+                let mut read_something = false;
+                let mut action = PostAction::Continue;
+
+                loop {
+                    match read(fd, &mut buf) {
+                        Ok(0) => {
+                            // The other end of the pipe was closed, mark ourselves
+                            // for removal.
+                            action = PostAction::Remove;
+                            break;
+                        }
+
+                        // Got one or more pings.
+                        Ok(_) => read_something = true,
+
+                        // Nothing more to read.
+                        Err(nix::errno::Errno::EAGAIN) => break,
+
+                        // Propagate error.
+                        Err(e) => return Err(e.into()),
+                    }
+                }
+
+                if read_something {
+                    callback((), &mut ());
+                }
+                Ok(action)
+            })
+            .map_err(|e| PingError(e.into()))
+    }
+
+    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+        self.pipe.register(poll, token_factory)
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &mut Poll,
+        token_factory: &mut TokenFactory,
+    ) -> crate::Result<()> {
+        self.pipe.reregister(poll, token_factory)
+    }
+
+    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+        self.pipe.unregister(poll)
+    }
+}
+
+impl Drop for PingSource {
+    fn drop(&mut self) {
+        if let Err(e) = close(self.pipe.file) {
+            log::warn!("[calloop] Failed to close read ping: {:?}", e);
+        }
+    }
+}
+
+// The sending end of the ping writes zeroes to the write end of the pipe.
+#[derive(Clone, Debug)]
+pub struct Ping {
+    pipe: Arc<CloseOnDrop>,
+}
+
+// The sending end of the ping writes zeroes to the write end of the pipe.
+impl Ping {
+    /// Send a ping to the `PingSource`
+    pub fn ping(&self) {
+        if let Err(e) = send_ping(self.pipe.0) {
+            log::warn!("[calloop] Failed to write a ping: {:?}", e);
+        }
+    }
+}


### PR DESCRIPTION
This separates and reorganises the underlying mechanics for the ping source, and implements an eventfd-based ping for Linux.

---

~~Currently a draft, but close to final.~~ Partly addresses #15, maybe there's an analogue for BSD-ishes?

Eventfd has a bit of a quirk I didn't think about until I got halfway through this. It gives you *one* fd instead of two like a pipe. This means that if you close that fd, eg. through `CloseOnDrop`, the receiving end's fd becomes invalid and so does the `Generic` source wrapping it. In practice you just get some `EBADFD` errors, but theoretically if the fd is reassigned you could get some extreme weirdness.

I solved this by (a) adding a `dup()` system call at creation to create separate reading and writing fds. Closing a duplicated fd does *not* affect others that are open, solving the first problem.

The other problem is that the source's fd has no way of signalling that the other fd has been closed. Adding another event source to handle this seemed like it would cancel out the performance/complexity benefits of using eventfd in the first place. I have attempted to solve this by using an `AtomicBool` flag wrapped in an `Arc`, keeping the sending handle thread-safe and cloneable.

This sort of begged the question for me though, how does the pipe-based ping handle this? The event-source-code seems to suggest that reading zero bytes from the pipe after it becomes readable means that the other end was closed. But I can't find any documentation saying that closing a pipe end will make the other end become readable in the first place. Anyway, it might be the case that there's no foolproof way to handle this. I'd welcome any suggestions.

Other notes:

- I marked some functions as `#[inline]`, not so much for performance reasons but more to indicate that they're just used as interchangeable pieces in the other helper functions.
- There's a common structure between the pipe and eventfd files (`send_ping()`, `drain_ping()` etc) even though these are private functions. It's not a suggestion that this structure be enforced. It's just that breaking those functions out of the pipe impl helped me build them back up for the eventfd impl. If you prefer them back in the event source, that's fine by me.
- I will add some of these notes in as comments, but perhaps after feedback in case there are any fundamental changes.
- This PR adds [cfg-if](https://crates.io/crates/cfg-if) as a dependency. It should have no runtime cost. I think it helps the implementation switching a bit.

Docs/links:
- [eventfd](https://man7.org/linux/man-pages/man2/eventfd.2.html)
- [pipe2](https://man7.org/linux/man-pages/man2/pipe.2.html)
- SO: [Do I get a notification from epoll when a fd is closed?](https://stackoverflow.com/questions/43034535/do-i-get-a-notification-from-epoll-when-a-fd-is-closed)