### PR TITLE
Update nix to 0.24, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ codecov = { repository = "Smithay/calloop" }
 
 [dependencies]
 log = "0.4"
-nix = "0.23"
+nix = { version = "0.24", default-features = false, features = ["event", "fs", "signal", "socket", "time"] }
 futures-util = { version = "0.3.5", optional = true, default-features = false, features = ["std"]}
 futures-io = { version = "0.3.5", optional = true }
 slotmap = "1.0"


### PR DESCRIPTION
This reduces clean build time slightly.