### PR TITLE
Mitigate transient source leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+#### Breaking changes
+
+- **Breaking:** The `TransientSource` is now an opaque type. It provides API methods for removing or
+  replacing the wrapped source. This mitigates a potential leak of registration data if the
+  TransientSource is replaced by direct assignment in a parent source.
+
 ## 0.10.1 -- 2022-06-20
 
 #### Additions

--- a/src/sources/ping.rs
+++ b/src/sources/ping.rs
@@ -141,7 +141,7 @@ mod tests {
         let wrapper = TransientSource::from(source);
 
         // Check that the source starts off in the wrapper.
-        assert!(!matches!(wrapper, TransientSource::None));
+        assert!(!wrapper.is_none());
 
         // Put the source in the loop.
 
@@ -169,7 +169,7 @@ mod tests {
         let wrapper = dispatcher.into_source_inner();
 
         // Check that the inner source is now gone.
-        assert!(matches!(wrapper, TransientSource::None));
+        assert!(wrapper.is_none());
     }
 
     #[test]
@@ -186,7 +186,7 @@ mod tests {
         let wrapper = TransientSource::from(source);
 
         // Check that the source starts off in the wrapper.
-        assert!(!matches!(wrapper, TransientSource::None));
+        assert!(!wrapper.is_none());
 
         // Put the source in the loop.
 
@@ -215,7 +215,7 @@ mod tests {
         let wrapper = dispatcher.into_source_inner();
 
         // Check that the inner source is now gone.
-        assert!(matches!(wrapper, TransientSource::None));
+        assert!(wrapper.is_none());
     }
 
     #[test]
@@ -234,7 +234,7 @@ mod tests {
         let sender2 = sender1.clone();
 
         // Check that the source starts off in the wrapper.
-        assert!(!matches!(wrapper, TransientSource::None));
+        assert!(!wrapper.is_none());
 
         // Put the source in the loop.
 
@@ -285,6 +285,6 @@ mod tests {
         let wrapper = dispatcher.into_source_inner();
 
         // Check that the inner source is now gone.
-        assert!(matches!(wrapper, TransientSource::None));
+        assert!(wrapper.is_none());
     }
 }

--- a/src/sources/transient.rs
+++ b/src/sources/transient.rs
@@ -97,15 +97,13 @@
 /// inner source, even if it actually needs to be unregistered or initially
 /// registered.
 ///
-/// ## Replacing or removing `TransientSource`s without leaking
+/// ## Replacing or removing `TransientSource`s
 ///
-/// It is possible to leak registration if you bypass the API of a
-/// `TransientSource`. "Leak registration" means you may end up with an entry in
-/// `epoll()` that cannot be removed (in the case of file descriptor-based
-/// sources), or an entry in some other data structure (eg. the `Timer`'s
-/// underlying heap structure). No unsoundness or undefined behaviour will
-/// result, but leaking file descriptors can result in errors or panics in a
-/// long running program.
+/// Not properly removing or replacing `TransientSource`s can cause spurious
+/// wakeups of the event loop, and in some cases can leak file descriptors or
+/// fail to free entries in Calloop's internal data structures. No unsoundness
+/// or undefined behaviour will result, but leaking file descriptors can result
+/// in errors or panics.
 ///
 /// If you want to remove a source before it returns `PostAction::Remove`, use
 /// the [`TransientSource::remove()`] method. If you want to replace a source
@@ -117,8 +115,7 @@
 ///
 /// If, instead, you directly assign a new source to the variable holding the
 /// `TransientSource`, the inner source will be dropped before it can be
-/// unregistered, resulting in a leak. For example, either of these assignments
-/// will cause a leak of the old source's registration:
+/// unregistered. For example:
 ///
 /// ```none,actually-rust-but-see-https://github.com/rust-lang/rust/issues/63193
 /// self.mpsc_receiver = Default::default();

--- a/src/sources/transient.rs
+++ b/src/sources/transient.rs
@@ -124,6 +124,10 @@ impl<T> TransientSource<T> {
         }
     }
 
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
     /// If a caller needs to flag the contained source for removal or
     /// registration, we need to replace the enum variant safely. This requires
     /// having a `None` value in there temporarily while we do the swap.

--- a/src/sources/transient.rs
+++ b/src/sources/transient.rs
@@ -210,6 +210,12 @@ impl<T> TransientSource<T> {
     }
 
     /// Removes the wrapped event source from the event loop and this wrapper.
+    ///
+    /// If this is called from outside of the event loop, you will need to wake
+    /// up the event loop for any changes to take place. If it is called from
+    /// within the event loop, you must return `PostAction::Reregister` from
+    /// your own event source's `process_events()`, and the source will be
+    /// unregistered as needed after it exits.
     pub fn remove(&mut self) {
         self.state.replace_state(TransientSourceState::Remove);
     }
@@ -221,8 +227,9 @@ impl<T> TransientSource<T> {
     ///
     /// If this is called from outside of the event loop, you will need to wake
     /// up the event loop for any changes to take place. If it is called from
-    /// within the event loop, the sources will be registered and unregistered
-    /// as needed after the current `process_events()` iteration.
+    /// within the event loop, you must return `PostAction::Reregister` from
+    /// your own event source's `process_events()`, and the sources will be
+    /// registered and unregistered as needed after it exits.
     pub fn replace(&mut self, new: T) {
         self.state
             .replace_state(|old| TransientSourceState::Replace { new, old });


### PR DESCRIPTION
This addresses #104. Yes, it doubles the size of the type, but I'm inclined to say that's not a huge deal, since you'd need more than that space to do this correctly at a higher level.

The two extra tests are a bit dense, but they basically test the edge cases that led to this in the first place. I have *not* squashed every commit - I've broken it into three parts:

- a minor API change
- the "before" state - a similar test, it passes, but shows the complexity required to do things correctly
- the "after" state - what you see here

Changelog update to follow.