### PR TITLE
Fix calloop double borrows take two

### DIFF
--- a/src/loop_logic.rs
+++ b/src/loop_logic.rs
@@ -365,24 +365,16 @@ impl<'l, Data> EventLoop<'l, Data> {
     }
 
     fn invoke_pre_run(&self, data: &mut Data) -> crate::Result<()> {
-        let keys = self
+        let sources = self
             .handle
             .inner
             .sources
             .borrow()
-            .keys()
+            .values()
+            .cloned()
             .collect::<Vec<_>>();
 
-        for key in keys {
-            let source = self
-                .handle()
-                .inner
-                .sources
-                .borrow()
-                .get(key)
-                .unwrap()
-                .clone();
-
+        for source in sources {
             source.pre_run(data)?;
         }
 
@@ -390,23 +382,16 @@ impl<'l, Data> EventLoop<'l, Data> {
     }
 
     fn invoke_post_run(&self, data: &mut Data) -> crate::Result<()> {
-        let keys = self
+        let sources = self
             .handle
             .inner
             .sources
             .borrow()
-            .keys()
+            .values()
+            .cloned()
             .collect::<Vec<_>>();
-        for key in keys {
-            let source = self
-                .handle()
-                .inner
-                .sources
-                .borrow()
-                .get(key)
-                .unwrap()
-                .clone();
 
+        for source in sources {
             source.post_run(data)?;
         }
 


### PR DESCRIPTION
This is a follow up to 1787237a21aa0eb44676f255dfa26e5a2a74b5df given that one source could be removed from another we can't operate on keys.

--

@elinorbgr I'm not quite sure if that's what you meant in matrix, but I'd ask the user to try repro with that patch.