### PR TITLE
Add a "block_on" function for executing futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed a crash due to double borrow when handling pre/post run hooks
 
+#### Additions
+
+- With the `block_on` feature enabled, the `EventLoop` method now has a `block_on` method that runs a future to completion on the event loop.
+
 #### Breaking changes
 
 - **Breaking:** The `TransientSource` is now an opaque type. It provides API methods for removing or

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,13 @@ futures-io = { version = "0.3.5", optional = true }
 slotmap = "1.0"
 thiserror = "1.0"
 vec_map = "0.8.2"
+pin-utils = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 futures = "0.3.5"
 
 [features]
+block_on = ["pin-utils"]
 executor = ["futures-util"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This PR adds a "block on" function to the `EventLoop` that serves a similar purpose as the [`block_on()`](https://docs.rs/async-io/latest/async_io/fn.block_on.html) function from `async_io`, where the event loop is polled during periods where the future would normally be blocked. I gated it behind a `block_on` feature, please let me know if it would be better to not gate it.