### PR TITLE
Prevent panics on overflow in timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - **Breaking:** The `TransientSource` is now an opaque type. It provides API methods for removing or
   replacing the wrapped source. This mitigates a potential leak of registration data if the
   TransientSource is replaced by direct assignment in a parent source.
+- **Breaking:** `Timer::current_deadline` returns `Option<Instant>`, so that it can return `None`
+  in the event of an overflow.
   
 ## 0.10.2 -- 2022-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bugfixes
 
 - Fixed a crash due to double borrow when handling pre/post run hooks
+- Fixes a panic that can occur when large `Duration`s are passed to `Timer::from_duration`.
 
 #### Breaking changes
 


### PR DESCRIPTION
In `master`, there is a panic that happens when a large `Duration` is passed into a `Timer`. For instance:

```rust
let _ = Timer::from_duration(Duration::MAX);
```

creates this panic:

```rust
thread 'sources::timer::tests::no_overflow' panicked at 'overflow when adding duration to instant', library/std/src/time.rs:408:9
```

This PR fixes this panic such that, instead of causing a panic with large durations, it instead makes sure the timer never goes off. This fix is also applied to `TimeoutFuture`.