### PR TITLE
Port to rustix from nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.56.0', 'stable', 'beta']
+        rust: ['1.63.0', 'stable', 'beta']
 
     runs-on: 'ubuntu-latest'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,12 @@ jobs:
           command: test
           args: --features "block_on executor"
 
+      - name: Run tests with signals
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features "block_on executor signals"
+
       - name: Run book tests
         uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == 'stable' || matrix.rust == 'beta' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Downgrade log
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.rust == '1.56.0' }}
+        if: ${{ matrix.rust == '1.63.0' }}
         with:
           command: update
           args: --package log --precise 0.4.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Breaking changes
 
+- Bump MSRV to 1.63
 - Make signals an optional feature under the `signals` features.
 - Replace the `nix` crate with standard library I/O errors and the `rustix` 
 crate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+#### Breaking changes
+
+- Make signals an optional feature under the `signals` features.
+- Replace the `nix` crate with standard library I/O errors and the `rustix` 
+crate.
+
 ## 0.11.0 -- 2023-06-05
 
 #### Bugfixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ codecov = { repository = "Smithay/calloop" }
 bitflags = "1.2"
 io-lifetimes = "1.0.3"
 log = "0.4"
-nix = { version = "0.26", default-features = false, features = ["event", "fs", "signal", "socket", "time"] }
+nix = { version = "0.26", default-features = false, features = ["signal"] }
 async-task = { version = "4.4.0", optional = true }
 futures-io = { version = "0.3.5", optional = true }
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1.0"
 pin-utils = { version = "0.1.0", optional = true }
 slab = "0.4.8"
 polling = "2.6.0"
+rustix = { version = "0.37.17", default-features = false, features = ["std", "fs"] }
 
 [dev-dependencies]
 futures = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 futures = "0.3.5"
-rustix = { version = "0.38", default-features = false, features = ["std", "fs", "net"] }
+rustix = { version = "0.38", default-features = false, features = ["std", "fs", "net", "pipe"] }
 
 [features]
 block_on = ["pin-utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [ "events", "loop", "callback", "eventloop", "unix" ]
 autotests = false
 edition = "2018"
 readme = "README.md"
-rust-version = "1.56.0"
+rust-version = "1.63.0"
 
 [workspace]
 members = [ "doc" ]
@@ -27,13 +27,13 @@ log = "0.4"
 nix = { version = "0.26", default-features = false, features = ["signal"], optional = true }
 pin-utils = { version = "0.1.0", optional = true }
 polling = "2.6.0"
-rustix = { version = "0.38", default-features = false, features = ["event", "fs", "std"] }
+rustix = { version = "0.38", default-features = false, features = ["event", "fs", "pipe", "std"] }
 slab = "0.4.8"
 thiserror = "1.0"
 
 [dev-dependencies]
 futures = "0.3.5"
-rustix = { version = "0.38", default-features = false, features = ["std", "fs", "net", "pipe"] }
+rustix = { version = "0.38", default-features = false, features = ["net"] }
 
 [features]
 block_on = ["pin-utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,20 +19,21 @@ members = [ "doc" ]
 codecov = { repository = "Smithay/calloop" }
 
 [dependencies]
+async-task = { version = "4.4.0", optional = true }
 bitflags = "1.2"
+futures-io = { version = "0.3.5", optional = true }
 io-lifetimes = "1.0.3"
 log = "0.4"
 nix = { version = "0.26", default-features = false, features = ["signal"], optional = true }
-async-task = { version = "4.4.0", optional = true }
-futures-io = { version = "0.3.5", optional = true }
-thiserror = "1.0"
 pin-utils = { version = "0.1.0", optional = true }
-slab = "0.4.8"
 polling = "2.6.0"
-rustix = { version = "0.37.17", default-features = false, features = ["std", "fs"] }
+rustix = { version = "0.38", default-features = false, features = ["event", "fs", "std"] }
+slab = "0.4.8"
+thiserror = "1.0"
 
 [dev-dependencies]
 futures = "0.3.5"
+rustix = { version = "0.38", default-features = false, features = ["std", "fs", "net"] }
 
 [features]
 block_on = ["pin-utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ codecov = { repository = "Smithay/calloop" }
 bitflags = "1.2"
 io-lifetimes = "1.0.3"
 log = "0.4"
-nix = { version = "0.26", default-features = false, features = ["signal"] }
+nix = { version = "0.26", default-features = false, features = ["signal"], optional = true }
 async-task = { version = "4.4.0", optional = true }
 futures-io = { version = "0.3.5", optional = true }
 thiserror = "1.0"
@@ -38,6 +38,7 @@ futures = "0.3.5"
 block_on = ["pin-utils"]
 executor = ["async-task"]
 nightly_coverage = []
+signals = ["nix"]
 
 [package.metadata.docs.rs]
 features = ["block_on", "executor"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,15 +41,6 @@ pub enum Error {
     OtherError(#[from] Box<dyn std::error::Error + Sync + Send>),
 }
 
-impl From<nix::errno::Errno> for Error {
-    /// Converts a [`nix::Error`] into a wrapped version of the equivalent
-    /// [`std::io::Error`].
-    #[cfg_attr(feature = "nightly_coverage", no_coverage)]
-    fn from(err: nix::errno::Errno) -> Self {
-        Into::<std::io::Error>::into(err).into()
-    }
-}
-
 impl From<Error> for std::io::Error {
     /// Converts Calloop's error type into a [`std::io::Error`].
     fn from(err: Error) -> Self {

--- a/src/loop_logic.rs
+++ b/src/loop_logic.rs
@@ -901,7 +901,7 @@ mod tests {
         assert!(!dispatched);
 
         // write something, the socket becomes readable
-        write(sock2, &[1, 2, 3]).unwrap();
+        write(&sock2, &[1, 2, 3]).unwrap();
         dispatched = false;
         event_loop
             .dispatch(Duration::ZERO, &mut dispatched)

--- a/src/loop_logic.rs
+++ b/src/loop_logic.rs
@@ -695,14 +695,10 @@ mod tests {
 
     #[test]
     fn insert_source_no_interest() {
-        use nix::unistd::{close, pipe};
-        use std::os::unix::io::FromRawFd;
+        use rustix::pipe::pipe;
 
         // Create a pipe to get an arbitrary fd.
-        let (read, write) = pipe().unwrap();
-        let read = unsafe { io_lifetimes::OwnedFd::from_raw_fd(read) };
-        // We don't need the write end.
-        close(write).unwrap();
+        let (read, _write) = pipe().unwrap();
 
         let source = crate::sources::generic::Generic::new(read, Interest::EMPTY, Mode::Level);
         let dispatcher = Dispatcher::new(source, |_, _, _| Ok(PostAction::Continue));
@@ -863,7 +859,7 @@ mod tests {
         let (sock1, sock2) = socketpair(
             AddressFamily::UNIX,
             SocketType::STREAM,
-            SocketFlags::CLOEXEC,
+            SocketFlags::empty(),
             None, // recv with DONTWAIT will suffice for platforms without SockFlag::SOCK_NONBLOCKING such as macOS
         )
         .unwrap();

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -12,7 +12,7 @@ pub mod channel;
 pub mod futures;
 pub mod generic;
 pub mod ping;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "singals"))]
 #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
 pub mod signals;
 pub mod timer;

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -12,7 +12,7 @@ pub mod channel;
 pub mod futures;
 pub mod generic;
 pub mod ping;
-#[cfg(all(target_os = "linux", feature = "singals"))]
+#[cfg(all(target_os = "linux", feature = "signals"))]
 #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
 pub mod signals;
 pub mod timer;

--- a/src/sources/ping/eventfd.rs
+++ b/src/sources/ping/eventfd.rs
@@ -21,7 +21,8 @@
 use std::sync::Arc;
 
 use io_lifetimes::{AsFd, BorrowedFd, OwnedFd};
-use rustix::io::{eventfd, read, write, Errno, EventfdFlags};
+use rustix::event::{eventfd, EventfdFlags};
+use rustix::io::{read, write, Errno};
 
 use super::PingError;
 use crate::{

--- a/src/sources/ping/pipe.rs
+++ b/src/sources/ping/pipe.rs
@@ -16,7 +16,7 @@ use crate::{
 #[inline]
 fn make_ends() -> std::io::Result<(OwnedFd, OwnedFd)> {
     use rustix::fs::{fcntl_getfl, fcntl_setfl, OFlags};
-    use rustix::io::pipe;
+    use rustix::pipe::pipe;
 
     let (read, write) = pipe()?;
 

--- a/src/sources/ping/pipe.rs
+++ b/src/sources/ping/pipe.rs
@@ -31,7 +31,7 @@ fn make_ends() -> std::io::Result<(OwnedFd, OwnedFd)> {
 #[cfg(not(target_os = "macos"))]
 #[inline]
 fn make_ends() -> std::io::Result<(OwnedFd, OwnedFd)> {
-    use rustix::io::{pipe_with, PipeFlags};
+    use rustix::pipe::{pipe_with, PipeFlags};
     Ok(pipe_with(PipeFlags::CLOEXEC | PipeFlags::NONBLOCK)?)
 }
 

--- a/tests/signals.rs
+++ b/tests/signals.rs
@@ -1,7 +1,7 @@
 // These tests cannot run as a regular test because cargo would spawn a thread to run it,
 // failing the signal masking. So we make our own, non-threaded harnessing
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "signals"))]
 fn main() {
     for test in self::test::TESTS {
         test();

--- a/tests/signals.rs
+++ b/tests/signals.rs
@@ -10,10 +10,10 @@ fn main() {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", feature = "signals")))]
 fn main() {}
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "signals"))]
 mod test {
     extern crate calloop;
     extern crate nix;


### PR DESCRIPTION
Ports parts of this crate from nix to rustix, which uses I/O safety by default and allows for the inlining of syscalls.

WIP because there are some features we need that `rustix` does not support yet.