### PR TITLE
Raise minimum `bitflags` version to v1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [ "doc" ]
 codecov = { repository = "Smithay/calloop" }
 
 [dependencies]
+bitflags = "1.2"
 io-lifetimes = "1.0.3"
 log = "0.4"
 nix = { version = "0.26", default-features = false, features = ["event", "fs", "signal", "socket", "time"] }


### PR DESCRIPTION
This is an issue uncovered by https://github.com/Smithay/wayland-rs/pull/629.
`calloop` relies on a call to `from_bits_unchecked()`:
https://github.com/Smithay/calloop/blob/0ba3f1e24417fdb07960e609cb65ed9b04a19c47/src/io.rs#L55
... which is only available since `bitflags` v1.2, but `nix` only requires v1.1.