### PR TITLE
Fix the additional lifecycle events to work as documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 #### Bugfixes
-- Make the additional lifecycle events match the docs
+- Fix `EventSource::before_handle_events()` being erroneously give an iterator over synthetic events instead of real events
 
 ## 0.12.0 -- 2023-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+#### Bugfixes
+- Make the additional lifecycle events match the docs
+
 ## 0.12.0 -- 2023-09-11
 
 #### Breaking changes


### PR DESCRIPTION
Required for https://github.com/Smithay/calloop-wayland-source/pull/1.

I think this only needs to be a patch release, as this just brings the behaviour in-line with the docs