### PR TITLE
Fix crash when dropping removed token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### Bugfixes
+
+- Fixed a crash when removing a token in a callback with a `PostAction::Remove`
+
 ## 0.12.2 -- 2023-09-25
 
 #### Bugfixes

--- a/src/loop_logic.rs
+++ b/src/loop_logic.rs
@@ -1105,6 +1105,23 @@ mod tests {
     }
 
     #[test]
+    fn remove_during_callback() {
+        use crate::sources::timer::{TimeoutAction, Timer};
+
+        let mut event_loop = EventLoop::<RegistrationToken>::try_new().unwrap();
+        let handle = event_loop.handle();
+        let mut token = event_loop
+            .handle()
+            .insert_source(Timer::immediate(), move |_, _, token| {
+                handle.remove(*token);
+                TimeoutAction::Drop
+            })
+            .unwrap();
+
+        event_loop.dispatch(Duration::ZERO, &mut token).unwrap();
+    }
+
+    #[test]
     fn insert_source_no_interest() {
         use rustix::pipe::pipe;
 


### PR DESCRIPTION
This fixes an issue where calloop would crash internally when the `PostAction::Drop` was invoked after the user manually cancelled the source in the callback.