### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,35 @@ jobs:
           command: test
           args: --all-features --manifest-path ./doc/Cargo.toml
 
+  ci-windows:
+    name: CI (Windows)
+
+    needs:
+      - lint
+
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: ['1.63.0', 'stable']
+
+    runs-on: 'windows-latest'
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features "block_on executor"
+
   coverage:
     name: Coverage
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "rust-analyzer.showUnlinkedFileNotification": false
+    "rust-analyzer.showUnlinkedFileNotification": false,
+    "rust-analyzer.cargo.target": "x86_64-pc-windows-gnu"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-    "rust-analyzer.showUnlinkedFileNotification": false,
-    "rust-analyzer.cargo.target": "x86_64-pc-windows-gnu"
+    "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,14 @@ async-task = { version = "4.4.0", optional = true }
 bitflags = "2.4"
 futures-io = { version = "0.3.5", optional = true }
 log = "0.4"
-nix = { version = "0.26", default-features = false, features = ["signal"], optional = true }
 pin-utils = { version = "0.1.0", optional = true }
 polling = "3.0.0"
-rustix = { version = "0.38", default-features = false, features = ["event", "fs", "pipe", "std"] }
 slab = "0.4.8"
+rustix = { version = "0.38", default-features = false, features = ["event", "fs", "pipe", "std"] }
 thiserror = "1.0.7"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.26", default-features = false, features = ["signal"], optional = true }
 
 [dev-dependencies]
 futures = "0.3.5"

--- a/src/io.rs
+++ b/src/io.rs
@@ -37,9 +37,9 @@ use crate::{AdditionalLifecycleEventsSet, RegistrationToken};
 /// `AsyncWrite` if the underlying type implements `Read` and/or `Write`.
 ///
 /// Note that this adapter and the futures procuded from it and *not* threadsafe.
-/// 
+///
 /// ## Platform-Specific
-/// 
+///
 /// - **Windows:** Usually, on drop, the file descriptor is set back to its previous status.
 ///   For example, if the file was previously nonblocking it will be set to nonblocking, and
 ///   if the file was blocking it will be set to blocking. However, on Windows, it is impossible
@@ -102,7 +102,7 @@ impl<'l, F: AsFd> Async<'l, F> {
             fd: Some(fd),
             dispatcher,
             inner,
-            was_nonblocking
+            was_nonblocking,
         })
     }
 

--- a/src/sources/generic.rs
+++ b/src/sources/generic.rs
@@ -7,7 +7,8 @@
 //! notification itself, and the monitored object is provided to your callback as the second
 //! argument.
 //!
-//! ```
+#![cfg_attr(unix, doc = "```")]
+#![cfg_attr(not(unix), doc = "```no_run")]
 //! # extern crate calloop;
 //! use calloop::{generic::Generic, Interest, Mode, PostAction};
 //!
@@ -15,7 +16,10 @@
 //! # let mut event_loop = calloop::EventLoop::<()>::try_new()
 //! #                .expect("Failed to initialize the event loop!");
 //! # let handle = event_loop.handle();
+//! # #[cfg(unix)]
 //! # let io_object = std::io::stdin();
+//! # #[cfg(windows)]
+//! # let io_object: std::net::TcpStream = panic!();
 //! handle.insert_source(
 //!     // wrap your IO object in a Generic, here we register for read readiness
 //!     // in level-triggering mode

--- a/src/sources/generic.rs
+++ b/src/sources/generic.rs
@@ -38,12 +38,13 @@
 //! [`EventSource`](crate::EventSource) implementation to them.
 
 use polling::Poller;
-use std::{
-    borrow,
-    marker::PhantomData,
-    ops,
-    os::unix::io::{AsFd, AsRawFd, BorrowedFd},
-    sync::Arc,
+use std::{borrow, marker::PhantomData, ops, sync::Arc};
+
+#[cfg(unix)]
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
+#[cfg(windows)]
+use std::os::windows::io::{
+    AsRawSocket as AsRawFd, AsSocket as AsFd, BorrowedSocket as BorrowedFd,
 };
 
 use crate::{EventSource, Interest, Mode, Poll, PostAction, Readiness, Token, TokenFactory};
@@ -79,8 +80,14 @@ impl<T: AsRawFd> ops::DerefMut for FdWrapper<T> {
 }
 
 impl<T: AsRawFd> AsFd for FdWrapper<T> {
+    #[cfg(unix)]
     fn as_fd(&self) -> BorrowedFd {
         unsafe { BorrowedFd::borrow_raw(self.0.as_raw_fd()) }
+    }
+
+    #[cfg(windows)]
+    fn as_socket(&self) -> BorrowedFd {
+        unsafe { BorrowedFd::borrow_raw(self.0.as_raw_socket()) }
     }
 }
 
@@ -134,9 +141,16 @@ impl<T> ops::Deref for NoIoDrop<T> {
 }
 
 impl<T: AsFd> AsFd for NoIoDrop<T> {
+    #[cfg(unix)]
     fn as_fd(&self) -> BorrowedFd<'_> {
         // SAFETY: The innter type is not mutated.
         self.0.as_fd()
+    }
+
+    #[cfg(windows)]
+    fn as_socket(&self) -> BorrowedFd<'_> {
+        // SAFETY: The innter type is not mutated.
+        self.0.as_socket()
     }
 }
 
@@ -199,7 +213,14 @@ impl<F: AsFd, E> Generic<F, E> {
 
         // Remove it from the poller.
         if let Some(poller) = self.poller.take() {
-            poller.delete(file.as_fd()).ok();
+            poller
+                .delete(
+                    #[cfg(unix)]
+                    file.as_fd(),
+                    #[cfg(windows)]
+                    file.as_socket(),
+                )
+                .ok();
         }
 
         file
@@ -226,7 +247,14 @@ impl<F: AsFd, E> Drop for Generic<F, E> {
     fn drop(&mut self) {
         // Remove it from the poller.
         if let (Some(file), Some(poller)) = (self.file.take(), self.poller.take()) {
-            poller.delete(file.as_fd()).ok();
+            poller
+                .delete(
+                    #[cfg(unix)]
+                    file.as_fd(),
+                    #[cfg(windows)]
+                    file.as_socket(),
+                )
+                .ok();
         }
     }
 }
@@ -307,7 +335,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(unix, test))]
 mod tests {
     use std::io::{Read, Write};
 

--- a/src/sources/ping.rs
+++ b/src/sources/ping.rs
@@ -22,9 +22,14 @@ mod eventfd;
 #[cfg(target_os = "linux")]
 use eventfd as platform;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(windows)]
+mod iocp;
+#[cfg(windows)]
+use iocp as platform;
+
+#[cfg(not(any(target_os = "linux", windows)))]
 mod pipe;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", windows)))]
 use pipe as platform;
 
 /// Create a new ping event source

--- a/src/sources/ping/iocp.rs
+++ b/src/sources/ping/iocp.rs
@@ -120,7 +120,7 @@ impl EventSource for PingSource {
                 poll_state.packet.event().key,
                 token
             );
-            return Ok(PostAction::Continue);
+            return Ok(crate::PostAction::Continue);
         }
 
         // Tell if we are registered.

--- a/src/sources/ping/iocp.rs
+++ b/src/sources/ping/iocp.rs
@@ -1,0 +1,298 @@
+//! IOCP-based implementation of the ping event source.
+//!
+//! The underlying `Poller` can be woken up at any time, using the `post` method
+//! to send an arbitrary packet to the I/O completion port. The complication is
+//! emulating a pipe.
+//!
+//! Since `Poller` is already wrapped in an `Arc`, we can clone it into some
+//! synchronized inner state to send a pre-determined packet into it. Thankfully
+//! calloop's use of the pipe is constrained enough that we can implement it using
+//! a simple bool to keep track of whether or not it is notified.
+
+use crate::sources::EventSource;
+
+use polling::os::iocp::{CompletionPacket, PollerIocpExt};
+use polling::Poller;
+
+use std::fmt;
+use std::io;
+use std::sync::{Arc, Mutex, TryLockError};
+
+#[inline]
+pub fn make_ping() -> io::Result<(Ping, PingSource)> {
+    let state = Arc::new(State {
+        counter: Mutex::new(Counter {
+            notified: false,
+            poll_state: None,
+        }),
+    });
+
+    Ok((
+        Ping {
+            state: state.clone(),
+        },
+        PingSource { state },
+    ))
+}
+
+/// The event to trigger.
+#[derive(Clone)]
+pub struct Ping {
+    state: Arc<State>,
+}
+
+impl fmt::Debug for Ping {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        debug_ping(&self.state, "Ping", f)
+    }
+}
+
+/// The event source.
+pub struct PingSource {
+    state: Arc<State>,
+}
+
+impl fmt::Debug for PingSource {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        debug_ping(&self.state, "PingSource", f)
+    }
+}
+
+impl Ping {
+    /// Send a ping to the `PingSource`.
+    pub fn ping(&self) {
+        let mut counter = self.state.counter.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Indicate that we are now notified.
+        counter.notified = true;
+
+        let poll_state = match &mut counter.poll_state {
+            Some(ps) => ps,
+            None => {
+                log::warn!("[calloop] ping was not registered with the event loop");
+                return;
+            }
+        };
+
+        // If we aren't currently inserted in the loop, send our packet.
+        if let Err(e) = poll_state.notify() {
+            log::warn!("[calloop] failed to post packet to IOCP: {}", e);
+        }
+    }
+}
+
+impl EventSource for PingSource {
+    type Error = super::PingError;
+    type Event = ();
+    type Metadata = ();
+    type Ret = ();
+
+    fn process_events<F>(
+        &mut self,
+        _readiness: crate::Readiness,
+        token: crate::Token,
+        mut callback: F,
+    ) -> Result<crate::PostAction, Self::Error>
+    where
+        F: FnMut(Self::Event, &mut Self::Metadata) -> Self::Ret,
+    {
+        let mut counter = self.state.counter.lock().unwrap_or_else(|e| e.into_inner());
+
+        // If we aren't registered, break out.
+        let poll_state = match &mut counter.poll_state {
+            Some(ps) => ps,
+            None => {
+                return Err(super::PingError(Box::new(io::Error::from(
+                    io::ErrorKind::NotFound,
+                ))));
+            }
+        };
+
+        // We are no longer inserted into the poller.
+        poll_state.inserted = false;
+
+        // Make sure this is our token.
+        let token: usize = token.inner.into();
+        if poll_state.packet.event().key != token {
+            log::warn!(
+                "[calloop] token does not match; expected {:x}, got {:x}",
+                poll_state.packet.event().key,
+                token
+            );
+        }
+
+        // Tell if we are registered.
+        if counter.notified {
+            counter.notified = false;
+
+            // Call the callback.
+            callback((), &mut ());
+        }
+
+        // Stop looping if all of the Ping's have been dropped.
+        let action = if Arc::strong_count(&self.state) == 1 {
+            crate::PostAction::Remove
+        } else {
+            crate::PostAction::Continue
+        };
+
+        Ok(action)
+    }
+
+    fn register(
+        &mut self,
+        poll: &mut crate::Poll,
+        token_factory: &mut crate::TokenFactory,
+    ) -> crate::Result<()> {
+        let mut counter = self.state.counter.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Make sure we haven't already been registered.
+        if counter.poll_state.is_none() {
+            return Err(io::Error::from(io::ErrorKind::AlreadyExists).into());
+        }
+
+        // Create the event to send.
+        let packet = {
+            let token = token_factory.token().inner.into();
+            let event = polling::Event::readable(token);
+            CompletionPacket::new(event)
+        };
+
+        // Create the poll state.
+        let poll_state = PollState::new(poll.poller(), packet, counter.notified)?;
+
+        // Substitute it into our poll state.
+        counter.poll_state = Some(poll_state);
+        Ok(())
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &mut crate::Poll,
+        _token_factory: &mut crate::TokenFactory,
+    ) -> crate::Result<()> {
+        let mut counter = self.state.counter.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Make sure that the poller has been registered.
+        let poll_state = match &mut counter.poll_state {
+            Some(ps) => ps,
+            None => return Err(io::Error::from(io::ErrorKind::NotFound).into()),
+        };
+
+        // If it's a different poller, throw an error.
+        if !Arc::ptr_eq(&poll_state.poller, poll.poller()) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "attempted to reregister() a PingSource with a different poller",
+            )
+            .into());
+        }
+
+        // Nothing should really be changed here.
+        Ok(())
+    }
+
+    fn unregister(&mut self, _poll: &mut crate::Poll) -> crate::Result<()> {
+        let mut counter = self.state.counter.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Remove our current registration.
+        counter.poll_state = None;
+        Ok(())
+    }
+}
+
+/// Inner state of the pipe.
+struct State {
+    /// The counter used to keep track of our state.
+    counter: Mutex<Counter>,
+}
+
+/// Inner counter of the pipe.
+struct Counter {
+    /// Are we notified?
+    notified: bool,
+
+    /// The `Poller`-related state.
+    ///
+    /// This is `None` if we aren't inserted into the `Poller` yet.
+    poll_state: Option<PollState>,
+}
+
+/// The `Poller` combined with some associated state.
+struct PollState {
+    /// The `Poller` that we are registered in.
+    poller: Arc<Poller>,
+
+    /// Are we inserted into the poller?
+    inserted: bool,
+
+    /// The completion packet to send.
+    packet: CompletionPacket,
+}
+
+impl PollState {
+    /// Create a new `PollState` based on the `Poller` and the `packet`.
+    ///
+    /// If `notified` is `true`, a packet is inserted into the poller.
+    fn new(poller: &Arc<Poller>, packet: CompletionPacket, notified: bool) -> io::Result<Self> {
+        let mut poll_state = Self {
+            poller: poller.clone(),
+            packet,
+            inserted: false,
+        };
+
+        if notified {
+            poll_state.notify()?;
+        }
+
+        Ok(poll_state)
+    }
+
+    /// Notify the poller.
+    fn notify(&mut self) -> io::Result<()> {
+        if !self.inserted {
+            self.poller.post(self.packet.clone())?;
+            self.inserted = true;
+        }
+
+        Ok(())
+    }
+}
+
+#[inline]
+fn debug_ping(state: &State, name: &str, f: &mut fmt::Formatter) -> fmt::Result {
+    let counter = match state.counter.try_lock() {
+        Ok(counter) => counter,
+        Err(TryLockError::WouldBlock) => {
+            return f
+                .debug_tuple("Ping")
+                .field(&format_args!("<locked>"))
+                .finish()
+        }
+        Err(TryLockError::Poisoned(_)) => {
+            return f
+                .debug_tuple("Ping")
+                .field(&format_args!("<poisoned>"))
+                .finish()
+        }
+    };
+
+    let mut s = f.debug_struct(name);
+    s.field("notified", &counter.notified);
+
+    // Tell if we are registered.
+    match &counter.poll_state {
+        Some(poll_state) => {
+            s.field("packet", poll_state.packet.event());
+            s.field("inserted", &poll_state.inserted);
+        }
+
+        None => {
+            s.field("packet", &format_args!("<not registered>"));
+        }
+    }
+
+    s.finish()
+}

--- a/src/sources/ping/iocp.rs
+++ b/src/sources/ping/iocp.rs
@@ -105,7 +105,7 @@ impl EventSource for PingSource {
             Some(ps) => ps,
             None => {
                 // We were deregistered; remove ourselves from the list.
-                return Ok(crate::PostAction::Remove); 
+                return Ok(crate::PostAction::Remove);
             }
         };
 

--- a/src/sources/ping/iocp.rs
+++ b/src/sources/ping/iocp.rs
@@ -149,7 +149,7 @@ impl EventSource for PingSource {
         let mut counter = self.state.counter.lock().unwrap_or_else(|e| e.into_inner());
 
         // Make sure we haven't already been registered.
-        if counter.poll_state.is_none() {
+        if counter.poll_state.is_some() {
             return Err(io::Error::from(io::ErrorKind::AlreadyExists).into());
         }
 


### PR DESCRIPTION
This commit adds Windows support to this package. Since polling already
has Windows support through IOCP, the main obstacle was adding a ping
event source using IOCP. The hardest part is emulating a pipe using some
shared state and a posted completion packet.

Fixes #161
