### PR TITLE
v0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.12.4 -- 2024-01-15
+
+#### Additions
+
+- `calloop` is now supported for Windows. (#168)
+- Add the `signals` feature to `docs.rs`. (#166)
+
+#### Bugfixes
+
+- Fix a borrow error that can occur while using the executor. (#165)
+
 ## 0.12.3 -- 2023-10-10
 
 #### Additions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calloop"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 documentation = "https://docs.rs/calloop/"
 repository = "https://github.com/Smithay/calloop"


### PR DESCRIPTION
## 0.12.4 -- 2024-01-15

#### Additions

- `calloop` is now supported for Windows. (#168)
- Add the `signals` feature to `docs.rs`. (#166)

#### Bugfixes

- Fix a borrow error that can occur while using the executor. (#165)
