### PR TITLE
executor: Fix issue when task is scheduled within event callback

### DIFF
--- a/src/sources/futures.rs
+++ b/src/sources/futures.rs
@@ -296,9 +296,6 @@ impl<T> EventSource for Executor<T> {
     {
         let state = &self.state;
 
-        // Set to the unnotified state.
-        state.sender.notified.store(false, Ordering::SeqCst);
-
         let clear_readiness = {
             let mut clear_readiness = false;
 
@@ -346,6 +343,9 @@ impl<T> EventSource for Executor<T> {
                 .process_events(readiness, token, |(), &mut ()| {})
                 .map_err(ExecutorError::WakeError)?;
         }
+
+        // Set to the unnotified state.
+        state.sender.notified.store(false, Ordering::SeqCst);
 
         Ok(PostAction::Continue)
     }


### PR DESCRIPTION
I believe this should be overall more correct. Previously, if the callback taken by `process_events` scheduled a task, `process_events` could exit with the readiness of `self.ping` cleared, but `notified` set to `true`. In which case, future calls to `schedule` would not wake the event source.

Fixes https://github.com/Smithay/calloop/issues/171.