### PR TITLE
v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.13.0 -- 2024-02-25
+
+#### Breaking changes
+
+- Bump `nix` to `v0.28`. As `nix` is exposed in the public API, this is a
+  breaking change. (#176)
+
+#### Bugfixes
+
+- Fix a panic that would occur when a task is scheduled in an event callback.
+  (#172)
+
 ## 0.12.4 -- 2024-01-15
 
 #### Additions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calloop"
-version = "0.12.4"
+version = "0.13.0"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 documentation = "https://docs.rs/calloop/"
 repository = "https://github.com/Smithay/calloop"


### PR DESCRIPTION
## 0.13.0 -- 2024-02-25

#### Breaking changes

- Bump `nix` to `v0.28`. As `nix` is exposed in the public API, this is a
  breaking change. (#176)

#### Bugfixes

- Fix a panic that would occur when a task is scheduled in an event callback.
  (#172)
