### PR TITLE
Replace thiserror with manual impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ pin-utils = { version = "0.1.0", optional = true }
 polling = "3.0.0"
 slab = "0.4.8"
 rustix = { version = "0.38", default-features = false, features = ["event", "fs", "pipe", "std"] }
-thiserror = "1.0.7"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28", default-features = false, features = ["signal"], optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidToken => f.write_str("invalid token provided to internal function"),
@@ -49,12 +50,14 @@ impl fmt::Display for Error {
 }
 
 impl From<std::io::Error> for Error {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn from(value: std::io::Error) -> Self {
         Self::IoError(value)
     }
 }
 
 impl From<Box<dyn std::error::Error + Sync + Send>> for Error {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn from(value: Box<dyn std::error::Error + Sync + Send>) -> Self {
         Self::OtherError(value)
     }
@@ -62,6 +65,7 @@ impl From<Box<dyn std::error::Error + Sync + Send>> for Error {
 
 impl From<Error> for std::io::Error {
     /// Converts Calloop's error type into a [`std::io::Error`].
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn from(err: Error) -> Self {
         match err {
             Error::IoError(source) => source,
@@ -72,6 +76,7 @@ impl From<Error> for std::io::Error {
 }
 
 impl std::error::Error for Error {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::InvalidToken => None,
@@ -100,6 +105,7 @@ impl<T> Debug for InsertError<T> {
 }
 
 impl<T> fmt::Display for InsertError<T> {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "error inserting event source: {}", &self.error)
     }
@@ -115,6 +121,7 @@ impl<T> From<InsertError<T>> for crate::Error {
 }
 
 impl<T> std::error::Error for InsertError<T> {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.error)
     }

--- a/src/sources/channel.rs
+++ b/src/sources/channel.rs
@@ -218,12 +218,14 @@ impl<T> EventSource for Channel<T> {
 pub struct ChannelError(PingError);
 
 impl fmt::Display for ChannelError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl std::error::Error for ChannelError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.0)
     }

--- a/src/sources/channel.rs
+++ b/src/sources/channel.rs
@@ -8,6 +8,7 @@
 //! A synchronous version of the channel is provided by [`sync_channel`], in which
 //! the [`SyncSender`] will block when the channel is full.
 
+use std::fmt;
 use std::sync::mpsc;
 
 use crate::{EventSource, Poll, PostAction, Readiness, Token, TokenFactory};
@@ -213,9 +214,20 @@ impl<T> EventSource for Channel<T> {
 }
 
 /// An error arising from processing events for a channel.
-#[derive(thiserror::Error, Debug)]
-#[error(transparent)]
+#[derive(Debug)]
 pub struct ChannelError(PingError);
+
+impl fmt::Display for ChannelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::error::Error for ChannelError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/sources/futures.rs
+++ b/src/sources/futures.rs
@@ -253,6 +253,7 @@ impl<T> Drop for Executor<T> {
 pub struct ExecutorDestroyed;
 
 impl fmt::Display for ExecutorDestroyed {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("the executor was destroyed")
     }
@@ -389,6 +390,7 @@ pub enum ExecutorError {
 }
 
 impl fmt::Display for ExecutorError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NewFutureError(err) => write!(f, "error adding new futures: {}", err),

--- a/src/sources/futures.rs
+++ b/src/sources/futures.rs
@@ -22,6 +22,7 @@ use async_task::{Builder, Runnable};
 use slab::Slab;
 use std::{
     cell::RefCell,
+    fmt,
     future::Future,
     rc::Rc,
     sync::{
@@ -248,9 +249,16 @@ impl<T> Drop for Executor<T> {
 
 /// Error generated when trying to schedule a future after the
 /// executor was destroyed.
-#[derive(thiserror::Error, Debug)]
-#[error("the executor was destroyed")]
+#[derive(Debug)]
 pub struct ExecutorDestroyed;
+
+impl fmt::Display for ExecutorDestroyed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("the executor was destroyed")
+    }
+}
+
+impl std::error::Error for ExecutorDestroyed {}
 
 /// Create a new executor, and its associated scheduler
 ///
@@ -371,16 +379,25 @@ impl<T> EventSource for Executor<T> {
 }
 
 /// An error arising from processing events in an async executor event source.
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug)]
 pub enum ExecutorError {
     /// Error while reading new futures added via [`Scheduler::schedule()`].
-    #[error("error adding new futures")]
     NewFutureError(ChannelError),
 
     /// Error while processing wake events from existing futures.
-    #[error("error processing wake events")]
     WakeError(PingError),
 }
+
+impl fmt::Display for ExecutorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NewFutureError(err) => write!(f, "error adding new futures: {}", err),
+            Self::WakeError(err) => write!(f, "error processing wake events: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for ExecutorError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/sources/ping.rs
+++ b/src/sources/ping.rs
@@ -62,12 +62,14 @@ pub type PingSource = platform::PingSource;
 pub struct PingError(Box<dyn std::error::Error + Sync + Send>);
 
 impl fmt::Display for PingError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl std::error::Error for PingError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&*self.0)
     }

--- a/src/sources/ping.rs
+++ b/src/sources/ping.rs
@@ -32,6 +32,8 @@ mod pipe;
 #[cfg(not(any(target_os = "linux", windows)))]
 use pipe as platform;
 
+use std::fmt;
+
 /// Create a new ping event source
 ///
 /// you are given a [`Ping`] instance, which can be cloned and used to ping the
@@ -56,9 +58,20 @@ pub type Ping = platform::Ping;
 pub type PingSource = platform::PingSource;
 
 /// An error arising from processing events for a ping.
-#[derive(thiserror::Error, Debug)]
-#[error(transparent)]
+#[derive(Debug)]
 pub struct PingError(Box<dyn std::error::Error + Sync + Send>);
+
+impl fmt::Display for PingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::error::Error for PingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&*self.0)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/sources/signals.rs
+++ b/src/sources/signals.rs
@@ -336,12 +336,14 @@ impl EventSource for Signals {
 pub struct SignalError(Box<dyn std::error::Error + Sync + Send>);
 
 impl fmt::Display for SignalError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
 impl std::error::Error for SignalError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&*self.0)
     }

--- a/src/sources/signals.rs
+++ b/src/sources/signals.rs
@@ -11,6 +11,7 @@
 //! they'll inherit their parent signal mask.
 
 use std::convert::TryFrom;
+use std::fmt;
 use std::io::Error as IoError;
 use std::os::raw::c_int;
 
@@ -331,6 +332,17 @@ impl EventSource for Signals {
 }
 
 /// An error arising from processing events for a process signal.
-#[derive(thiserror::Error, Debug)]
-#[error(transparent)]
+#[derive(Debug)]
 pub struct SignalError(Box<dyn std::error::Error + Sync + Send>);
+
+impl fmt::Display for SignalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::error::Error for SignalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&*self.0)
+    }
+}


### PR DESCRIPTION
This commit removes the heavy thiserror dependency by replacing its
automatically generated implementations with manually written ones. Hopefully
the newly written implementations are identical to the previous ones, but just
in case I've marked this as a breaking change. Since there is already a breaking change on master this shouldn't be a big deal.

Closes #126
