### PR TITLE
Docs: fix minor typos in links to async chapters

### DIFF
--- a/doc/src/ch03-00-async-await.md
+++ b/doc/src/ch03-00-async-await.md
@@ -1,3 +1,3 @@
 # Async/await in calloop
 
-While it is centered on event sources and callbacks, calloop also provides adapters to integrate with Rust's async ecosystem. These adapters come in two parts: [a futures executor](chp03-01-run-async-code.md) and [an async adapter for IO type](chp03-02-async-io.md).
+While it is centered on event sources and callbacks, calloop also provides adapters to integrate with Rust's async ecosystem. These adapters come in two parts: [a futures executor](ch03-01-run-async-code.md) and [an async adapter for IO type](ch03-02-async-io-types.md).


### PR DESCRIPTION
The current links are throwing 404 errors.