### PR TITLE
ci: Remove log downgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,6 @@ jobs:
           path: target
           key: ${{ runner.os }}-test-${{ steps.rustcversion.outputs.version }}-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Downgrade log
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.rust == '1.63.0' }}
-        with:
-          command: update
-          args: --package log --precise 0.4.16
-
       - name: Downgrade regex
         uses: actions-rs/cargo@v1
         if: ${{ matrix.rust == '1.63.0' }}


### PR DESCRIPTION
The current version of log is compatible with the MSRV of calloop
