### PR TITLE
Make `Generic` `UnwindSafe` even if its error type isn't

### DIFF
--- a/src/sources/generic.rs
+++ b/src/sources/generic.rs
@@ -42,7 +42,7 @@
 //! [`EventSource`](crate::EventSource) implementation to them.
 
 use polling::Poller;
-use std::{borrow, marker::PhantomData, ops, sync::Arc};
+use std::{borrow, marker::PhantomData, ops, panic::AssertUnwindSafe, sync::Arc};
 
 #[cfg(unix)]
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
@@ -180,7 +180,7 @@ pub struct Generic<F: AsFd, E = std::io::Error> {
     token: Option<Token>,
 
     // This allows us to make the associated error and return types generic.
-    _error_type: PhantomData<E>,
+    _error_type: PhantomData<AssertUnwindSafe<E>>,
 }
 
 impl<F: AsFd> Generic<F, std::io::Error> {


### PR DESCRIPTION
`std::io::Error` does not implement `UnwindSafe` on account of its ability to wrap a `Box<dyn Error + Send + Sync>`. This infects `Generic` which in turn infects `Channel`, which is inconvenient because it means you can't construct a channel pair, pass the receiver side to a child thread, and then handles panics in the child.

But this is silly, because the error parameter to `Generic` is just a phantom. We aren't really wrapping an error at all, let alone downcasting it to a mutable reference and mucking with the referent. This patch changes the `PhantomData<E>` to `PhantomData<AssertUnwindSafe<E>>` so that `Generic<F, E>` can be `UnwindSafe` as long as `F` is.