### PR TITLE
On same deadline, items queued first have priority

### DIFF
--- a/src/sources/timer.rs
+++ b/src/sources/timer.rs
@@ -278,7 +278,8 @@ impl TimerWheel {
 impl std::cmp::Ord for TimeoutData {
     #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // earlier values have priority, on same deadline items queued first have priority
+        // Earlier values have priority.
+        // For items with the same deadline, those queued first have priority.
         self.deadline
             .cmp(&other.deadline)
             .then_with(|| self.counter.cmp(&other.counter))


### PR DESCRIPTION
When multiple are registered at the same time, those registered first should have priority to make scheduling behavior easier to predict. I don't think this should be added as documented behavior to prevent users from depending on it.

One nice to have follow up would be to start supporting custom prioritization as tie-breaker so users can define their own to handle tie-breaking. Right now users depend on tweaking expire timestamps to get same effect, which is not clean. 