### PR TITLE
Remove `mut` from `Poll`

### DIFF
--- a/doc/src/zmqsource.rs
+++ b/doc/src/zmqsource.rs
@@ -202,7 +202,7 @@ where
 
     fn register(
         &mut self,
-        poll: &mut calloop::Poll,
+        poll: &calloop::Poll,
         token_factory: &mut calloop::TokenFactory,
     ) -> calloop::Result<()> {
         self.socket.register(poll, token_factory)?;
@@ -216,7 +216,7 @@ where
 
     fn reregister(
         &mut self,
-        poll: &mut calloop::Poll,
+        poll: &calloop::Poll,
         token_factory: &mut calloop::TokenFactory,
     ) -> calloop::Result<()> {
         self.socket.reregister(poll, token_factory)?;
@@ -228,7 +228,7 @@ where
         Ok(())
     }
 
-    fn unregister(&mut self, poll: &mut calloop::Poll) -> calloop::Result<()> {
+    fn unregister(&mut self, poll: &calloop::Poll) -> calloop::Result<()> {
         self.socket.unregister(poll)?;
         self.mpsc_receiver.unregister(poll)?;
         self.wake_ping_receiver.unregister(poll)?;

--- a/src/io.rs
+++ b/src/io.rs
@@ -202,7 +202,7 @@ trait IoLoopInner {
 impl<'l, Data> IoLoopInner for LoopInner<'l, Data> {
     unsafe fn register(&self, dispatcher: &RefCell<IoDispatcher>) -> crate::Result<()> {
         let disp = dispatcher.borrow();
-        self.poll.borrow_mut().register(
+        self.poll.register(
             unsafe { BorrowedFd::borrow_raw(disp.fd) },
             Interest::EMPTY,
             Mode::OneShot,
@@ -212,7 +212,7 @@ impl<'l, Data> IoLoopInner for LoopInner<'l, Data> {
 
     fn reregister(&self, dispatcher: &RefCell<IoDispatcher>) -> crate::Result<()> {
         let disp = dispatcher.borrow();
-        self.poll.borrow_mut().reregister(
+        self.poll.reregister(
             unsafe { BorrowedFd::borrow_raw(disp.fd) },
             disp.interest,
             Mode::OneShot,
@@ -263,7 +263,7 @@ impl<Data> EventDispatcher<Data> for RefCell<IoDispatcher> {
 
     fn register(
         &self,
-        _: &mut Poll,
+        _: &Poll,
         _: &mut AdditionalLifecycleEventsSet,
         _: &mut TokenFactory,
     ) -> crate::Result<()> {
@@ -273,7 +273,7 @@ impl<Data> EventDispatcher<Data> for RefCell<IoDispatcher> {
 
     fn reregister(
         &self,
-        _: &mut Poll,
+        _: &Poll,
         _: &mut AdditionalLifecycleEventsSet,
         _: &mut TokenFactory,
     ) -> crate::Result<bool> {
@@ -283,7 +283,7 @@ impl<Data> EventDispatcher<Data> for RefCell<IoDispatcher> {
 
     fn unregister(
         &self,
-        poll: &mut Poll,
+        poll: &Poll,
         _: &mut AdditionalLifecycleEventsSet,
         _: RegistrationToken,
     ) -> crate::Result<bool> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -140,7 +140,7 @@ mod tests {
 
         fn register(
             &mut self,
-            poll: &mut crate::Poll,
+            poll: &crate::Poll,
             token_factory: &mut crate::TokenFactory,
         ) -> crate::Result<()> {
             crate::batch_register!(poll, token_factory, self.ping0, self.ping1, self.ping2)
@@ -148,13 +148,13 @@ mod tests {
 
         fn reregister(
             &mut self,
-            poll: &mut crate::Poll,
+            poll: &crate::Poll,
             token_factory: &mut crate::TokenFactory,
         ) -> crate::Result<()> {
             crate::batch_reregister!(poll, token_factory, self.ping0, self.ping1, self.ping2)
         }
 
-        fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+        fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
             crate::batch_unregister!(poll, self.ping0, self.ping1, self.ping2)
         }
     }

--- a/src/sources/channel.rs
+++ b/src/sources/channel.rs
@@ -246,19 +246,19 @@ impl<T> EventSource for Channel<T> {
         }
     }
 
-    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+    fn register(&mut self, poll: &Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
         self.source.register(poll, token_factory)
     }
 
     fn reregister(
         &mut self,
-        poll: &mut Poll,
+        poll: &Poll,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()> {
         self.source.reregister(poll, token_factory)
     }
 
-    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+    fn unregister(&mut self, poll: &Poll) -> crate::Result<()> {
         self.source.unregister(poll)
     }
 }

--- a/src/sources/futures.rs
+++ b/src/sources/futures.rs
@@ -367,21 +367,21 @@ impl<T> EventSource for Executor<T> {
         }
     }
 
-    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+    fn register(&mut self, poll: &Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
         self.source.register(poll, token_factory)?;
         Ok(())
     }
 
     fn reregister(
         &mut self,
-        poll: &mut Poll,
+        poll: &Poll,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()> {
         self.source.reregister(poll, token_factory)?;
         Ok(())
     }
 
-    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+    fn unregister(&mut self, poll: &Poll) -> crate::Result<()> {
         self.source.unregister(poll)?;
         Ok(())
     }

--- a/src/sources/generic.rs
+++ b/src/sources/generic.rs
@@ -290,7 +290,7 @@ where
         callback(readiness, self.file.as_mut().unwrap())
     }
 
-    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+    fn register(&mut self, poll: &Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
         let token = token_factory.token();
 
         // SAFETY: We ensure that we have a poller to deregister with (see below).
@@ -315,7 +315,7 @@ where
 
     fn reregister(
         &mut self,
-        poll: &mut Poll,
+        poll: &Poll,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()> {
         let token = token_factory.token();
@@ -331,7 +331,7 @@ where
         Ok(())
     }
 
-    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+    fn unregister(&mut self, poll: &Poll) -> crate::Result<()> {
         poll.unregister(&self.file.as_ref().unwrap().0)?;
         self.poller = None;
         self.token = None;

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -148,7 +148,7 @@ pub trait EventSource {
     ///
     /// If you need to register more than one file descriptor, you can change the
     /// `sub_id` field of the [`Token`](crate::Token) to differentiate between them.
-    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()>;
+    fn register(&mut self, poll: &Poll, token_factory: &mut TokenFactory) -> crate::Result<()>;
 
     /// Re-register your file descriptors
     ///
@@ -157,7 +157,7 @@ pub trait EventSource {
     /// if necessary.
     fn reregister(
         &mut self,
-        poll: &mut Poll,
+        poll: &Poll,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()>;
 
@@ -165,7 +165,7 @@ pub trait EventSource {
     ///
     /// You should unregister all your file descriptors from this [`Poll`](crate::Poll) using its
     /// [`Poll::unregister`](crate::Poll#method.unregister) method.
-    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()>;
+    fn unregister(&mut self, poll: &Poll) -> crate::Result<()>;
 
     /// Whether this source needs to be sent the [`EventSource::before_sleep`]
     /// and [`EventSource::before_handle_events`] notifications. These are opt-in because
@@ -221,19 +221,19 @@ impl<T: EventSource> EventSource for Box<T> {
         T::process_events(&mut **self, readiness, token, callback)
     }
 
-    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+    fn register(&mut self, poll: &Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
         T::register(&mut **self, poll, token_factory)
     }
 
     fn reregister(
         &mut self,
-        poll: &mut Poll,
+        poll: &Poll,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()> {
         T::reregister(&mut **self, poll, token_factory)
     }
 
-    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+    fn unregister(&mut self, poll: &Poll) -> crate::Result<()> {
         T::unregister(&mut **self, poll)
     }
 
@@ -269,19 +269,19 @@ impl<T: EventSource> EventSource for &mut T {
         T::process_events(&mut **self, readiness, token, callback)
     }
 
-    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+    fn register(&mut self, poll: &Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
         T::register(&mut **self, poll, token_factory)
     }
 
     fn reregister(
         &mut self,
-        poll: &mut Poll,
+        poll: &Poll,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()> {
         T::reregister(&mut **self, poll, token_factory)
     }
 
-    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+    fn unregister(&mut self, poll: &Poll) -> crate::Result<()> {
         T::unregister(&mut **self, poll)
     }
 
@@ -330,7 +330,7 @@ where
 
     fn register(
         &self,
-        poll: &mut Poll,
+        poll: &Poll,
         additional_lifecycle_register: &mut AdditionalLifecycleEventsSet,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()> {
@@ -344,7 +344,7 @@ where
 
     fn reregister(
         &self,
-        poll: &mut Poll,
+        poll: &Poll,
         additional_lifecycle_register: &mut AdditionalLifecycleEventsSet,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<bool> {
@@ -361,7 +361,7 @@ where
 
     fn unregister(
         &self,
-        poll: &mut Poll,
+        poll: &Poll,
         additional_lifecycle_register: &mut AdditionalLifecycleEventsSet,
         registration_token: RegistrationToken,
     ) -> crate::Result<bool> {
@@ -399,21 +399,21 @@ pub(crate) trait EventDispatcher<Data> {
 
     fn register(
         &self,
-        poll: &mut Poll,
+        poll: &Poll,
         additional_lifecycle_register: &mut AdditionalLifecycleEventsSet,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()>;
 
     fn reregister(
         &self,
-        poll: &mut Poll,
+        poll: &Poll,
         additional_lifecycle_register: &mut AdditionalLifecycleEventsSet,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<bool>;
 
     fn unregister(
         &self,
-        poll: &mut Poll,
+        poll: &Poll,
         additional_lifecycle_register: &mut AdditionalLifecycleEventsSet,
         registration_token: RegistrationToken,
     ) -> crate::Result<bool>;

--- a/src/sources/ping/pipe.rs
+++ b/src/sources/ping/pipe.rs
@@ -113,19 +113,19 @@ impl EventSource for PingSource {
             .map_err(|e| PingError(e.into()))
     }
 
-    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+    fn register(&mut self, poll: &Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
         self.pipe.register(poll, token_factory)
     }
 
     fn reregister(
         &mut self,
-        poll: &mut Poll,
+        poll: &Poll,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()> {
         self.pipe.reregister(poll, token_factory)
     }
 
-    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+    fn unregister(&mut self, poll: &Poll) -> crate::Result<()> {
         self.pipe.unregister(poll)
     }
 }

--- a/src/sources/timer.rs
+++ b/src/sources/timer.rs
@@ -142,7 +142,7 @@ impl EventSource for Timer {
         Ok(PostAction::Continue)
     }
 
-    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+    fn register(&mut self, poll: &Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
         // Only register a deadline if we haven't overflowed.
         if let Some(deadline) = self.deadline {
             let wheel = poll.timers.clone();
@@ -160,14 +160,14 @@ impl EventSource for Timer {
 
     fn reregister(
         &mut self,
-        poll: &mut Poll,
+        poll: &Poll,
         token_factory: &mut TokenFactory,
     ) -> crate::Result<()> {
         self.unregister(poll)?;
         self.register(poll, token_factory)
     }
 
-    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+    fn unregister(&mut self, poll: &Poll) -> crate::Result<()> {
         if let Some(registration) = self.registration.take() {
             poll.timers.borrow_mut().cancel(registration.counter);
         }

--- a/src/sources/transient.rs
+++ b/src/sources/transient.rs
@@ -294,7 +294,7 @@ impl<T: crate::EventSource> crate::EventSource for TransientSource<T> {
 
     fn register(
         &mut self,
-        poll: &mut crate::Poll,
+        poll: &crate::Poll,
         token_factory: &mut crate::TokenFactory,
     ) -> crate::Result<()> {
         match &mut self.state {
@@ -318,7 +318,7 @@ impl<T: crate::EventSource> crate::EventSource for TransientSource<T> {
 
     fn reregister(
         &mut self,
-        poll: &mut crate::Poll,
+        poll: &crate::Poll,
         token_factory: &mut crate::TokenFactory,
     ) -> crate::Result<()> {
         match &mut self.state {
@@ -345,7 +345,7 @@ impl<T: crate::EventSource> crate::EventSource for TransientSource<T> {
         Ok(())
     }
 
-    fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+    fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
         match &mut self.state {
             TransientSourceState::Keep(source)
             | TransientSourceState::Register(source)
@@ -414,7 +414,7 @@ mod tests {
 
             fn register(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.ping.register(poll, token_factory)
@@ -422,13 +422,13 @@ mod tests {
 
             fn reregister(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.ping.reregister(poll, token_factory)
             }
 
-            fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+            fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
                 self.ping.unregister(poll)
             }
         }
@@ -561,7 +561,7 @@ mod tests {
 
             fn register(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.ping.register(poll, token_factory)
@@ -569,13 +569,13 @@ mod tests {
 
             fn reregister(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.ping.reregister(poll, token_factory)
             }
 
-            fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+            fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
                 self.ping.unregister(poll)
             }
         }
@@ -604,7 +604,7 @@ mod tests {
 
             fn register(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.0.map(|inner| inner.id += 1);
@@ -613,14 +613,14 @@ mod tests {
 
             fn reregister(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.0.map(|inner| inner.id += 1);
                 self.0.reregister(poll, token_factory)
             }
 
-            fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+            fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
                 self.0.map(|inner| inner.id += 1);
                 self.0.unregister(poll)
             }
@@ -710,7 +710,7 @@ mod tests {
 
             fn register(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.0.register(poll, token_factory)
@@ -718,13 +718,13 @@ mod tests {
 
             fn reregister(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.0.reregister(poll, token_factory)
             }
 
-            fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+            fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
                 self.0.unregister(poll)
             }
         }
@@ -837,7 +837,7 @@ mod tests {
 
             fn register(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.registered = true;
@@ -846,13 +846,13 @@ mod tests {
 
             fn reregister(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.source.reregister(poll, token_factory)
             }
 
-            fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+            fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
                 self.registered = false;
                 self.source.unregister(poll)
             }
@@ -942,7 +942,7 @@ mod tests {
 
             fn register(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.current.register(poll, token_factory)
@@ -950,13 +950,13 @@ mod tests {
 
             fn reregister(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.current.reregister(poll, token_factory)
             }
 
-            fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+            fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
                 self.current.unregister(poll)
             }
         }
@@ -1078,7 +1078,7 @@ mod tests {
 
             fn register(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.inner.register(poll, token_factory)
@@ -1086,13 +1086,13 @@ mod tests {
 
             fn reregister(
                 &mut self,
-                poll: &mut crate::Poll,
+                poll: &crate::Poll,
                 token_factory: &mut crate::TokenFactory,
             ) -> crate::Result<()> {
                 self.inner.reregister(poll, token_factory)
             }
 
-            fn unregister(&mut self, poll: &mut crate::Poll) -> crate::Result<()> {
+            fn unregister(&mut self, poll: &crate::Poll) -> crate::Result<()> {
                 self.inner.unregister(poll)
             }
         }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -180,7 +180,7 @@ pub struct Poll {
     ///
     /// One can emulate level triggered events on top of oneshot events by just re-registering the
     /// file descriptor every time it is polled. However, this is not ideal, as it requires a
-    /// system call every time. It's better to use the intergrated system, if available.
+    /// system call every time. It's better to use the integrated system, if available.
     level_triggered: Option<RefCell<HashMap<usize, (Raw, polling::Event)>>>,
 
     pub(crate) timers: Rc<RefCell<TimerWheel>>,


### PR DESCRIPTION
The `Poll` already has interior mutability, so wrap it with `RefCell` is unnecessary. This is a breaking change though.