### PR TITLE
v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.14.2 -- 2024-12-03
+
+#### Bugfixes
+
+- Simplify the way timeouts are calculated for `Poll`. (#214)
+
 ## 0.14.1 -- 2024-09-05
 
 #### Additions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calloop"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 documentation = "https://docs.rs/calloop/"
 repository = "https://github.com/Smithay/calloop"


### PR DESCRIPTION
- Simplify the way timeouts are calculated for `Poll`. (#214)