### PR TITLE
Fix Grammar Mistake in Warning

### DIFF
--- a/src/loop_logic.rs
+++ b/src/loop_logic.rs
@@ -602,7 +602,7 @@ impl<'l, Data> EventLoop<'l, Data> {
                     }
                 }
             } else {
-                warn!(?reg_token, "Received an event for non-existence source");
+                warn!(?reg_token, "Received an event for non-existent source");
             }
         }
 


### PR DESCRIPTION
Noticed this when I bumped into https://github.com/alacritty/alacritty/issues/8449.

Just a tiny grammar thing.