### PR TITLE
v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.14.3 - 2025-03-08
+
+- Add `WeakLoopHandle`. (#216)
+
 ## 0.14.2 -- 2024-12-03
 
 #### Bugfixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calloop"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["Elinor Berger <elinor@safaradeg.net>"]
 documentation = "https://docs.rs/calloop/"
 repository = "https://github.com/Smithay/calloop"


### PR DESCRIPTION
## 0.14.3 - 2025-03-08

- Manually derive `Clone` and `Default` on `WeakLoopHandle`. (#219)

