### PR TITLE
source/futures: Fix handling of `notified` atomic

### DIFF
--- a/src/sources/futures.rs
+++ b/src/sources/futures.rs
@@ -309,15 +309,15 @@ impl<T> EventSource for Executor<T> {
     {
         let state = &self.state;
 
-        // Set to the unnotified state.
-        state.sender.notified.store(false, Ordering::SeqCst);
-
         let (clear_readiness, action) = {
             let mut clear_readiness = false;
 
             let action = self
                 .source
                 .process_events(readiness, token, |(), &mut ()| {
+                    // Set to the unnotified state.
+                    state.sender.notified.store(false, Ordering::SeqCst);
+
                     // Process runnables, but not too many at a time; better to move onto the next event quickly!
                     for _ in 0..1024 {
                         let runnable = match state.incoming.try_recv() {


### PR DESCRIPTION
Previously, `notified` was cleared before the
`self.source.process_events` call. This meant that it was cleared before reading from the ping source eventfd/pipe.

This means that a call to `send()` form a waker in a different thread could call `ping()` before this has been read, and prevent future calls to `ping()`. But `process_events()` won't be woken again, freezing the executor.

This seems to fix an issue I've seen in `cosmic-workspaces` when trying to use the `calloop` executor.