### PR TITLE
Add `StreamSource` to adapt an async `Stream` to an `EventSource`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ codecov = { repository = "Smithay/calloop" }
 [dependencies]
 async-task = { version = "4.4.0", optional = true }
 bitflags = "2.4"
+futures-core = { version = "0.3.31", optional = true }
 futures-io = { version = "0.3.5", optional = true }
 pin-utils = { version = "0.1.0", optional = true }
 polling = "3.0.0"
@@ -41,9 +42,10 @@ block_on = ["pin-utils"]
 executor = ["async-task"]
 nightly_coverage = []
 signals = ["nix"]
+stream = ["futures-core"]
 
 [package.metadata.docs.rs]
-features = ["block_on", "executor", "signals"]
+features = ["block_on", "executor", "signals", "stream"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [[test]]

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -18,6 +18,8 @@ pub mod ping;
 #[cfg(all(target_os = "linux", feature = "signals"))]
 #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
 pub mod signals;
+#[cfg(feature = "stream")]
+pub mod stream;
 pub mod timer;
 pub mod transient;
 

--- a/src/sources/stream.rs
+++ b/src/sources/stream.rs
@@ -1,0 +1,142 @@
+//! Adapt a [`Stream`] into an event source
+//!
+//! Only available with the `stream` cargo feature of `calloop`.
+//!
+//! The stream will be polled by the event loop, allowing the event source's
+//! callback to handle each event from the stream. This allows streams that
+//! are woken by events in a different thread to be naturally integrated into
+//! a `calloop` event loop.
+
+use futures_core::Stream;
+use std::{
+    fmt,
+    pin::pin,
+    sync::Arc,
+    task::{Context, Wake, Waker},
+};
+
+use crate::{
+    ping::{make_ping, Ping, PingError, PingSource},
+    EventSource, Poll, PostAction, Readiness, Token, TokenFactory,
+};
+
+struct PingWaker(Ping);
+
+impl Wake for PingWaker {
+    fn wake(self: Arc<Self>) {
+        self.0.ping();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.0.ping();
+    }
+}
+
+/// [`Stream`]-based event source.
+#[derive(Debug)]
+pub struct StreamSource<S: Stream + Unpin> {
+    stream: S,
+    source: PingSource,
+    waker: Waker,
+}
+
+impl<S: Stream + Unpin> StreamSource<S> {
+    /// Create event source for a [`Stream`].
+    pub fn new(stream: S) -> crate::Result<Self> {
+        let (ping, source) = make_ping()?;
+
+        // Signal the ping source so the stream will be polled initially,
+        // and the waker registered.
+        ping.ping();
+
+        let waker = Waker::from(Arc::new(PingWaker(ping)));
+
+        Ok(Self {
+            stream: stream,
+            source,
+            waker,
+        })
+    }
+}
+
+impl<S: Stream + Unpin> EventSource for StreamSource<S> {
+    type Event = Option<S::Item>;
+    type Metadata = ();
+    type Ret = ();
+    type Error = StreamError;
+
+    fn process_events<F>(
+        &mut self,
+        readiness: Readiness,
+        token: Token,
+        mut callback: F,
+    ) -> Result<PostAction, Self::Error>
+    where
+        F: FnMut(Option<S::Item>, &mut ()),
+    {
+        let mut context = Context::from_waker(&self.waker);
+        let mut stream = pin!(&mut self.stream);
+        let mut end_of_stream = false;
+        let action = self
+            .source
+            .process_events(readiness, token, |(), &mut ()| {
+                while let std::task::Poll::Ready(evt) = stream.as_mut().poll_next(&mut context) {
+                    if let Some(evt) = evt {
+                        callback(Some(evt), &mut ());
+                    } else {
+                        callback(None, &mut ());
+                        end_of_stream = true;
+                        break;
+                    }
+                }
+            })?;
+        if end_of_stream {
+            Ok(PostAction::Remove)
+        } else {
+            Ok(action)
+        }
+    }
+
+    fn register(&mut self, poll: &mut Poll, token_factory: &mut TokenFactory) -> crate::Result<()> {
+        self.source.register(poll, token_factory)?;
+        Ok(())
+    }
+
+    fn reregister(
+        &mut self,
+        poll: &mut Poll,
+        token_factory: &mut TokenFactory,
+    ) -> crate::Result<()> {
+        self.source.reregister(poll, token_factory)?;
+        Ok(())
+    }
+
+    fn unregister(&mut self, poll: &mut Poll) -> crate::Result<()> {
+        self.source.unregister(poll)?;
+        Ok(())
+    }
+}
+
+/// An error arising from processing events for a stream.
+#[derive(Debug)]
+pub struct StreamError(PingError);
+
+impl fmt::Display for StreamError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::error::Error for StreamError {
+    #[cfg_attr(feature = "nightly_coverage", coverage(off))]
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl From<PingError> for StreamError {
+    fn from(err: PingError) -> Self {
+        Self(err)
+    }
+}


### PR DESCRIPTION
Async `Stream`s are logically quite similar an `EventSource`, though not tied to fd polling. So it's quite natural to insert a stream as a calloop source, and then have a callback handle any value yielded by the stream. This behaves similarly to the `Channel` source.

Previously, this would require an executor, either the calloop one or an executor on a different thread, running a future that iterates over the stream and send return values on a calloop channel. This adapter event source is simpler to use and more efficient, for cases where one or a few streams need to be handled, but there's not a need to schedule very large numbers of them, or run on multiple threads.