### PR TITLE
Remove FreeBSD 15 Snap from Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,9 +6,6 @@ task:
     - name: FreeBSD 14.2
       freebsd_instance:
         image_family: freebsd-14-2
-    - name: FreeBSD 15.0
-      freebsd_instance:
-        image_family: freebsd-15-0-snap
  # Install Rust
   setup_script:
     - fetch https://sh.rustup.rs -o rustup.sh


### PR DESCRIPTION
Cirrus isn't allocating us these pods, so we can't use them.

Signed-off-by: John Nunley <dev@notgull.net>
